### PR TITLE
Add VehiclePositions module to fetch live coordinates of buses

### DIFF
--- a/lib/aucklandia.rb
+++ b/lib/aucklandia.rb
@@ -1,6 +1,7 @@
 require "aucklandia/version"
 require "aucklandia/routes"
 require "aucklandia/trips"
+require "aucklandia/vehicle_positions"
 require "aucklandia/client"
 
 require 'rest-client'

--- a/lib/aucklandia/client.rb
+++ b/lib/aucklandia/client.rb
@@ -2,6 +2,7 @@ module Aucklandia
   class Client
     include Aucklandia::Routes
     include Aucklandia::Trips
+    include Aucklandia::VehiclePositions
 
     attr_reader :authorization_key
     def initialize(authorization_key)

--- a/lib/aucklandia/vehicle_positions.rb
+++ b/lib/aucklandia/vehicle_positions.rb
@@ -1,0 +1,18 @@
+module Aucklandia
+	module VehiclePositions
+    VEHICLE_POSITIONS_ENDPOINT = '/public/realtime/vehiclelocations'
+
+    def get_vehicle_positions(trip_id=nil)
+      url = [BASE_URL, VEHICLE_POSITIONS_ENDPOINT].join('')
+
+      url << "?trip_id=#{trip_id}" if trip_id
+
+      response = RestClient::Request.execute(method: :get,
+                                             url: url,
+                                             headers: headers)
+                                    .body
+
+      JSON.parse(response)['response']['entity']
+    end
+	end
+end

--- a/spec/aucklandia/vehicle_positions_spec.rb
+++ b/spec/aucklandia/vehicle_positions_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+RSpec.describe Aucklandia::VehiclePositions do
+  let(:client) { Aucklandia::Client.new('password123') }
+
+	describe '#get_vehicle_positions' do
+		context 'with no provided parameters' do
+			context 'active vehicles' do
+				it 'responds with a collection of all live vehicle positions' do
+					payload = File.read('spec/fixtures/get-vehicle-positions-successful.json')
+	        successful_payload = instance_double('RestClient::Response', body: payload)
+
+	        allow(RestClient::Request).to receive(:execute)
+	                                  .and_return(successful_payload)
+
+					expect(client.get_vehicle_positions).to_not be_empty
+					client.get_vehicle_positions.each do |vehicle_position|
+						expect(vehicle_position).to have_key 'vehicle'
+					end
+				end
+			end
+
+			context 'with trip_id parameter' do
+				it 'responds with a collection of vehicle positions' do
+					payload = File.read('spec/fixtures/get-vehicle-positions-with-trip-id-successful.json')
+					successful_payload = instance_double('RestClient::Response', body: payload)
+
+	        allow(RestClient::Request).to receive(:execute)
+	                                  .and_return(successful_payload)
+
+	        trip_id =  JSON.parse(payload)['response']['entity'].first['vehicle']['trip']['trip_id']
+
+	        client.get_vehicle_positions(trip_id).each do |vehicle_position|
+		        expect(vehicle_position).to have_key 'vehicle'
+		        expect(vehicle_position['vehicle']['trip']['trip_id']).to eql trip_id
+	        end
+				end
+			end
+		end
+	end
+end

--- a/spec/fixtures/get-vehicle-positions-successful.json
+++ b/spec/fixtures/get-vehicle-positions-successful.json
@@ -1,0 +1,7917 @@
+{
+    "status": "OK",
+    "response": {
+        "header": {
+            "gtfs_realtime_version": "1.0",
+            "incrementality": 0,
+            "timestamp": 1535531310.317
+        },
+        "entity": [
+            {
+                "id": "7862b4c0-bdb7-c6fd-0bf2-beab8e853f57",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "439138115-20180815114333_v70.9",
+                        "route_id": "03008-20180815114333_v70.9",
+                        "start_time": "20:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "37FA"
+                    },
+                    "position": {
+                        "latitude": -36.92404333,
+                        "longitude": 174.78403833
+                    },
+                    "timestamp": 1535531308,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "90832993-e9b2-6b94-e843-89539edae1d5",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "476138026-20180815114333_v70.9",
+                        "route_id": "72113-20180815114333_v70.9",
+                        "start_time": "19:27:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "37E6"
+                    },
+                    "position": {
+                        "latitude": -36.857383,
+                        "longitude": 174.781667,
+                        "bearing": "330"
+                    },
+                    "timestamp": 1535531297.938,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "9171ae21-82ad-0b6c-9639-1a1a49ec6792",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "14306133937-20180815114333_v70.9",
+                        "route_id": "30902-20180815114333_v70.9",
+                        "start_time": "19:30:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "6791"
+                    },
+                    "position": {
+                        "latitude": -36.98111667,
+                        "longitude": 174.77533667
+                    },
+                    "timestamp": 1535531240
+                }
+            },
+            {
+                "id": "33066ab6-5df8-a020-9794-1c10545aefa5",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "12879120970-20180815114333_v70.9",
+                        "route_id": "87902-20180815114333_v70.9",
+                        "start_time": "19:20:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "3760"
+                    },
+                    "position": {
+                        "latitude": -36.695183,
+                        "longitude": 174.751317,
+                        "bearing": "312"
+                    },
+                    "timestamp": 1535531299.866,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "147007ec-eb5f-f411-6baf-4884d05a2a7c",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "50051144502-20180815114333_v70.9",
+                        "route_id": "850002-20180815114333_v70.9",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "AMP        633"
+                    },
+                    "position": {
+                        "latitude": -37.00001,
+                        "longitude": 174.86124,
+                        "bearing": 161
+                    },
+                    "timestamp": 1535531281
+                }
+            },
+            {
+                "id": "a6744c76-2438-6e8f-0fe6-eefaf1a13ab9",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "3100089211-20180815114333_v70.9",
+                        "route_id": "10002-20180815114333_v70.9",
+                        "start_time": "20:08:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "563B"
+                    },
+                    "position": {
+                        "latitude": -36.751817,
+                        "longitude": 174.728283,
+                        "bearing": "320"
+                    },
+                    "timestamp": 1535531269.978,
+                    "occupancy_status": 1
+                }
+            },
+            {
+                "id": "fa8507c9-e62b-41c9-b283-557184e9bcfa",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1141102767-20180815114333_v70.9",
+                        "route_id": "07006-20180815114333_v70.9",
+                        "start_time": "20:05:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5EB5"
+                    },
+                    "position": {
+                        "latitude": -36.896583,
+                        "longitude": 174.805683,
+                        "bearing": "110"
+                    },
+                    "timestamp": 1535531289.242,
+                    "occupancy_status": 2
+                }
+            },
+            {
+                "id": "89f9d4d8-0c55-4504-05f8-00b3b4f68720",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1092125215-20180815114333_v70.9",
+                        "route_id": "14101-20180815114333_v70.9",
+                        "start_time": "20:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5C51"
+                    },
+                    "position": {
+                        "latitude": -36.87859667,
+                        "longitude": 174.632575
+                    },
+                    "timestamp": 1535531304,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "236af9d9-3c1d-be6e-cf60-3d66c7781bc0",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "476138174-20180815114333_v70.9",
+                        "route_id": "72113-20180815114333_v70.9",
+                        "start_time": "20:27:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "36C3"
+                    },
+                    "position": {
+                        "latitude": -36.85030089,
+                        "longitude": 174.76235608
+                    },
+                    "timestamp": 1535531302,
+                    "occupancy_status": 1
+                }
+            },
+            {
+                "id": "b5acf433-6c89-9440-a288-af7c6b9cfb09",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "17000144508-20180815114333_v70.9",
+                        "route_id": "810007-20180815114333_v70.9",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "AMP        402"
+                    },
+                    "position": {
+                        "latitude": -36.86706,
+                        "longitude": 174.77955,
+                        "bearing": 23
+                    },
+                    "timestamp": 1535531288
+                }
+            },
+            {
+                "id": "5e898112-26f6-9274-3b00-8a0321d47c6f",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1062112600-20180815114333_v70.9",
+                        "route_id": "03102-20180815114333_v70.9",
+                        "start_time": "19:10:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "672B"
+                    },
+                    "position": {
+                        "latitude": -36.98058667,
+                        "longitude": 174.77269
+                    },
+                    "timestamp": 1535531297
+                }
+            },
+            {
+                "id": "e684017d-b758-60c5-2342-128c4448fbd9",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1097097385-20180815114333_v70.9",
+                        "route_id": "16102-20180815114333_v70.9",
+                        "start_time": "20:15:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "57EB"
+                    },
+                    "position": {
+                        "latitude": -36.894167,
+                        "longitude": 174.666517,
+                        "bearing": "23"
+                    },
+                    "timestamp": 1535531297,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "3fa0ed2a-45e4-b987-68a8-33639fa3581c",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1098125222-20180815114333_v70.9",
+                        "route_id": "16202-20180815114333_v70.9",
+                        "start_time": "20:10:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "2F7A"
+                    },
+                    "position": {
+                        "latitude": -36.88715,
+                        "longitude": 174.650833,
+                        "bearing": "320"
+                    },
+                    "timestamp": 1535531299.761,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "ef8d2eac-8246-1e03-942c-87d2bd4720a0",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1141102777-20180815114333_v70.9",
+                        "route_id": "07006-20180815114333_v70.9",
+                        "start_time": "20:20:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5EBE"
+                    },
+                    "position": {
+                        "latitude": -36.854884,
+                        "longitude": 174.76739319
+                    },
+                    "timestamp": 1535531306,
+                    "occupancy_status": 1
+                }
+            },
+            {
+                "id": "3ab4fc49-62bc-5e0a-4351-e4c3aa98eac9",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1085125213-20180815114333_v70.9",
+                        "route_id": "12003-20180815114333_v70.9",
+                        "start_time": "20:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5915"
+                    },
+                    "position": {
+                        "latitude": -36.79469263,
+                        "longitude": 174.65671015
+                    },
+                    "timestamp": 1535531305,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "51fa90ba-62bc-e6d3-7a2c-de71080dd41c",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "454138160-20180815114333_v70.9",
+                        "route_id": "74402-20180815114333_v70.9",
+                        "start_time": "20:20:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "6670"
+                    },
+                    "position": {
+                        "latitude": -36.866733,
+                        "longitude": 174.859083,
+                        "bearing": "140"
+                    },
+                    "timestamp": 1535531291.652,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "93652ea3-8cf2-00dc-de11-576359e623c4",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "3100089092-20180815114333_v70.9",
+                        "route_id": "10003-20180815114333_v70.9",
+                        "start_time": "19:30:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5635"
+                    },
+                    "position": {
+                        "latitude": -36.73905667,
+                        "longitude": 174.71504333
+                    },
+                    "timestamp": 1535531292
+                }
+            },
+            {
+                "id": "84514252-dbfb-1410-dc54-1f47bcac2b22",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "3886089167-20180815114333_v70.9",
+                        "route_id": "88602-20180815114333_v70.9",
+                        "start_time": "20:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5710"
+                    },
+                    "position": {
+                        "latitude": -36.700733,
+                        "longitude": 174.747767,
+                        "bearing": "56"
+                    },
+                    "timestamp": 1535531303.252,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "ce3834d1-b6c8-b9c1-0d57-b0503aa87412",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "456138180-20180815114333_v70.9",
+                        "route_id": "75102-20180815114333_v70.9",
+                        "start_time": "20:30:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "36E8"
+                    },
+                    "position": {
+                        "latitude": -36.870317,
+                        "longitude": 174.778217
+                    },
+                    "timestamp": 1535531290,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "c7c467f5-aded-1b1b-0ac1-dd67f3bd7f0d",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "12858117477-20180815114333_v70.9",
+                        "route_id": "85801-20180815114333_v70.9",
+                        "start_time": "19:38:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "36FD"
+                    },
+                    "position": {
+                        "latitude": -36.846133,
+                        "longitude": 174.75655,
+                        "bearing": "110"
+                    },
+                    "timestamp": 1535531306.931,
+                    "occupancy_status": 1
+                }
+            },
+            {
+                "id": "1f6d80e0-cb31-8d71-89f6-870da91a9548",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1090109439-20180815114333_v70.9",
+                        "route_id": "13302-20180815114333_v70.9",
+                        "start_time": "19:55:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5C4E"
+                    },
+                    "position": {
+                        "latitude": -36.880867,
+                        "longitude": 174.638233,
+                        "bearing": "304"
+                    },
+                    "timestamp": 1535531195.38,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "d8d65d6a-a3f0-cb13-39da-7cb631df40ab",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "461138086-20180815114333_v70.9",
+                        "route_id": "78202-20180815114333_v70.9",
+                        "start_time": "19:50:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "662C"
+                    },
+                    "position": {
+                        "latitude": -36.91835833,
+                        "longitude": 174.84010667
+                    },
+                    "timestamp": 1535531309,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "53cd5493-963a-0ace-e709-abd3bfc54a1a",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "460138177-20180815114333_v70.9",
+                        "route_id": "78104-20180815114333_v70.9",
+                        "start_time": "20:30:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "3810"
+                    },
+                    "position": {
+                        "latitude": -36.870317,
+                        "longitude": 174.778217
+                    },
+                    "timestamp": 1535531284,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "227fb7e1-b4e7-2071-0ff6-3d6b5665372d",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1147102771-20180815114333_v70.9",
+                        "route_id": "71203-20180815114333_v70.9",
+                        "start_time": "20:15:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "662E"
+                    },
+                    "position": {
+                        "latitude": -36.890583,
+                        "longitude": 174.90855,
+                        "bearing": "10"
+                    },
+                    "timestamp": 1535531303.648,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "3d1af250-9ee6-9f05-1aab-5ae9a3328900",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "12875117498-20180815114333_v70.9",
+                        "route_id": "87501-20180815114333_v70.9",
+                        "start_time": "19:58:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "3727"
+                    },
+                    "position": {
+                        "latitude": -36.78556829,
+                        "longitude": 174.75660744
+                    },
+                    "timestamp": 1535531302,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "ba6c284f-f7da-d4b6-c1f0-9f457fc6c387",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "476138154-20180815114333_v70.9",
+                        "route_id": "73112-20180815114333_v70.9",
+                        "start_time": "20:15:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "36C8"
+                    },
+                    "position": {
+                        "latitude": -36.866817,
+                        "longitude": 174.778567,
+                        "bearing": "184"
+                    },
+                    "timestamp": 1535531297.895,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "24d3c66b-1a26-9e0e-bdd7-acc7f245d08f",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "3100089138-20180815114333_v70.9",
+                        "route_id": "10004-20180815114333_v70.9",
+                        "start_time": "19:45:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "576D"
+                    },
+                    "position": {
+                        "latitude": -36.624267,
+                        "longitude": 174.667567,
+                        "bearing": "0"
+                    },
+                    "timestamp": 1535531150.5,
+                    "occupancy_status": 1
+                }
+            },
+            {
+                "id": "02177fdb-cbdf-5877-96f4-536eaf8cb9c9",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "449138111-20180815114333_v70.9",
+                        "route_id": "29801-20180815114333_v70.9",
+                        "start_time": "20:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "6630"
+                    },
+                    "position": {
+                        "latitude": -36.91295,
+                        "longitude": 174.826367,
+                        "bearing": "128"
+                    },
+                    "timestamp": 1535531302.158,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "08ef208c-e42b-d43a-ff98-228cc73f0bf9",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "51100144524-20180815114333_v70.9",
+                        "route_id": "840006-20180815114333_v70.9",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "AMP        157"
+                    },
+                    "position": {
+                        "latitude": -36.88015983333333,
+                        "longitude": 174.78433,
+                        "bearing": 135
+                    },
+                    "timestamp": 1535531289
+                }
+            },
+            {
+                "id": "f1e44f8c-6cbd-d431-1484-9183b5fbaaec",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "14306133940-20180815114333_v70.9",
+                        "route_id": "30902-20180815114333_v70.9",
+                        "start_time": "19:55:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "678A"
+                    },
+                    "position": {
+                        "latitude": -36.933083,
+                        "longitude": 174.78805,
+                        "bearing": "153"
+                    },
+                    "timestamp": 1535531306.455,
+                    "occupancy_status": 1
+                }
+            },
+            {
+                "id": "5a736554-fb4b-e3c1-3583-16dae6257604",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1154105514-20180815114333_v70.9",
+                        "route_id": "73502-20180815114333_v70.9",
+                        "start_time": "19:55:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "663E"
+                    },
+                    "position": {
+                        "latitude": -36.95031833,
+                        "longitude": 174.89931333
+                    },
+                    "timestamp": 1535531260
+                }
+            },
+            {
+                "id": "2a67fc72-25f5-a168-7f52-6c28e4d17999",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1089109424-20180815114333_v70.9",
+                        "route_id": "13201-20180815114333_v70.9",
+                        "start_time": "19:45:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5C40"
+                    },
+                    "position": {
+                        "latitude": -36.845783,
+                        "longitude": 174.762667,
+                        "bearing": "194"
+                    },
+                    "timestamp": 1535531201,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "b5506fb5-7f50-bdb4-f3cc-6f5db9d509ea",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1140121063-20180815114333_v70.9",
+                        "route_id": "03505-20180815114333_v70.9",
+                        "start_time": "20:30:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5E67"
+                    },
+                    "position": {
+                        "latitude": -36.99355,
+                        "longitude": 174.8786
+                    },
+                    "timestamp": 1535531222,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "17666415-4ff2-0f12-5f0e-c288276f618b",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "473143308-20180815114333_v70.9",
+                        "route_id": "02702-20180815114333_v70.9",
+                        "start_time": "20:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "380D"
+                    },
+                    "position": {
+                        "latitude": -36.916567,
+                        "longitude": 174.7513,
+                        "bearing": "215"
+                    },
+                    "timestamp": 1535531305.947,
+                    "occupancy_status": 1
+                }
+            },
+            {
+                "id": "e9becf01-0204-d1de-6fb5-991c8a7364ab",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "3880089191-20180815114333_v70.9",
+                        "route_id": "88001-20180815114333_v70.9",
+                        "start_time": "20:05:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "56B3"
+                    },
+                    "position": {
+                        "latitude": -36.72645,
+                        "longitude": 174.7479,
+                        "bearing": "258"
+                    },
+                    "timestamp": 1535531305.612,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "aa4f090d-97d1-3b6f-6cb6-b112138b0886",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1089125206-20180815114333_v70.9",
+                        "route_id": "13206-20180815114333_v70.9",
+                        "start_time": "19:47:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5C44"
+                    },
+                    "position": {
+                        "latitude": -36.84465333,
+                        "longitude": 174.65164333
+                    },
+                    "timestamp": 1535531280,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "91e5dc8c-50d2-f315-20ce-333eabd2346a",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1084117452-20180815114333_v70.9",
+                        "route_id": "11401-20180815114333_v70.9",
+                        "start_time": "19:20:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "59DA"
+                    },
+                    "position": {
+                        "latitude": -36.913885,
+                        "longitude": 174.74932833
+                    },
+                    "timestamp": 1535531230
+                }
+            },
+            {
+                "id": "ac9f8b24-e7de-ebf1-b24c-d5d5a2702289",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "12891100568-20180815114333_v70.9",
+                        "route_id": "89102-20180815114333_v70.9",
+                        "start_time": "19:50:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "3811"
+                    },
+                    "position": {
+                        "latitude": -36.722117,
+                        "longitude": 174.712083,
+                        "bearing": "0"
+                    },
+                    "timestamp": 1535531159.5,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "85eedb90-d475-292f-afb0-c97b7a854795",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1140121026-20180815114333_v70.9",
+                        "route_id": "03505-20180815114333_v70.9",
+                        "start_time": "20:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5E71"
+                    },
+                    "position": {
+                        "latitude": -36.93485,
+                        "longitude": 174.91298
+                    },
+                    "timestamp": 1535531073,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "561d0fce-cbff-372f-d179-8acaebe2b10a",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "471138136-20180815114333_v70.9",
+                        "route_id": "02707-20180815114333_v70.9",
+                        "start_time": "20:07:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "3BD0"
+                    },
+                    "position": {
+                        "latitude": -36.877983,
+                        "longitude": 174.761233,
+                        "bearing": "355"
+                    },
+                    "timestamp": 1535531301.024,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "e226334c-ecb8-aecd-3814-914111849164",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "2366143327-20180815114333_v70.9",
+                        "route_id": "36605-20180815114333_v70.9",
+                        "start_time": "20:30:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "56FD"
+                    },
+                    "position": {
+                        "latitude": -37.023683,
+                        "longitude": 174.8958
+                    },
+                    "timestamp": 1535531243,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "6ecca6f7-f86c-9b7e-6c7a-4cd55b843675",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "439137299-20180815114333_v70.9",
+                        "route_id": "03008-20180815114333_v70.9",
+                        "start_time": "16:20:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "2A35"
+                    },
+                    "position": {
+                        "latitude": -36.92495667,
+                        "longitude": 174.79101167
+                    },
+                    "timestamp": 1535531154
+                }
+            },
+            {
+                "id": "380fb96c-131b-82df-1eaf-4dcdb32afaeb",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "8300141163-20180815114333_v70.9",
+                        "route_id": "30001-20180815114333_v70.9",
+                        "start_time": "20:15:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "620C"
+                    },
+                    "position": {
+                        "latitude": -36.990967,
+                        "longitude": 174.78615,
+                        "bearing": "350"
+                    },
+                    "timestamp": 1535531293.835,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "8cc84d94-b7bd-daf4-aa9c-a62aaae5e66f",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "475138141-20180815114333_v70.9",
+                        "route_id": "79821-20180815114333_v70.9",
+                        "start_time": "20:10:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "36C9"
+                    },
+                    "position": {
+                        "latitude": -36.8604,
+                        "longitude": 174.7669,
+                        "bearing": "110"
+                    },
+                    "timestamp": 1535531296.704,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "53cf788b-db83-e96b-89e7-a78c79964157",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1130125203-20180815114333_v70.9",
+                        "route_id": "19508-20180815114333_v70.9",
+                        "start_time": "19:45:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "57FC"
+                    },
+                    "position": {
+                        "latitude": -36.935083,
+                        "longitude": 174.6719,
+                        "bearing": "215"
+                    },
+                    "timestamp": 1535531296.392,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "067471d6-3239-320c-ed7d-42e0c6a624a2",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "2362143306-20180815114333_v70.9",
+                        "route_id": "36203-20180815114333_v70.9",
+                        "start_time": "20:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5605"
+                    },
+                    "position": {
+                        "latitude": -36.99395,
+                        "longitude": 174.879983,
+                        "bearing": "266"
+                    },
+                    "timestamp": 1535531282.138,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "13e9298b-3e63-3c1e-d18a-a2d5df896cdf",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "7380123829-20180815114333_v70.9",
+                        "route_id": "38014-20180815114333_v70.9",
+                        "start_time": "19:27:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "65FF"
+                    },
+                    "position": {
+                        "latitude": -36.97875,
+                        "longitude": 174.860333,
+                        "bearing": "125"
+                    },
+                    "timestamp": 1535531298.689,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "c5a61052-e2fc-65c0-c160-6b9c831e0fa0",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1120109248-20180815114333_v70.9",
+                        "route_id": "12504-20180815114333_v70.9",
+                        "start_time": "18:25:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "3077"
+                    },
+                    "position": {
+                        "latitude": -36.80197333,
+                        "longitude": 174.59672
+                    },
+                    "timestamp": 1535531225
+                }
+            },
+            {
+                "id": "4fb06e60-ef60-2365-321b-f45803efc350",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "465138170-20180815114333_v70.9",
+                        "route_id": "02202-20180815114333_v70.9",
+                        "start_time": "20:25:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "2F6B"
+                    },
+                    "position": {
+                        "latitude": -36.84848479,
+                        "longitude": 174.76347694
+                    },
+                    "timestamp": 1535531306,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "72fee5bc-1363-a27f-6260-56c74d3a312c",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "17000144451-20180815114333_v70.9",
+                        "route_id": "810002-20180815114333_v70.9",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "AMP        524"
+                    },
+                    "position": {
+                        "latitude": -36.85108,
+                        "longitude": 174.77575983333332,
+                        "bearing": 163
+                    },
+                    "timestamp": 1535531290
+                }
+            },
+            {
+                "id": "bdf58f32-9f64-9976-0f3c-82ae14a7846e",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "463138060-20180815114333_v70.9",
+                        "route_id": "02208-20180815114333_v70.9",
+                        "start_time": "19:37:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "307E"
+                    },
+                    "position": {
+                        "latitude": -36.85959,
+                        "longitude": 174.75617167
+                    },
+                    "timestamp": 1535531169
+                }
+            },
+            {
+                "id": "d8aaa0f3-7ce2-8173-be43-d3927cc667b8",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "441138116-20180815114333_v70.9",
+                        "route_id": "06801-20180815114333_v70.9",
+                        "start_time": "20:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "2F50"
+                    },
+                    "position": {
+                        "latitude": -36.92395167,
+                        "longitude": 174.78467833
+                    },
+                    "timestamp": 1535531154,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "14bdd2cf-caec-9cad-f39d-335585d9e5c7",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1087109277-20180815114333_v70.9",
+                        "route_id": "12501-20180815114333_v70.9",
+                        "start_time": "18:35:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "2F6E"
+                    },
+                    "position": {
+                        "latitude": -36.628395,
+                        "longitude": 174.50232667
+                    },
+                    "timestamp": 1535531252
+                }
+            },
+            {
+                "id": "76e2751c-1cc8-f1af-a00a-f7a47664ea80",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "440138042-20180815114333_v70.9",
+                        "route_id": "06601-20180815114333_v70.9",
+                        "start_time": "19:30:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5A30"
+                    },
+                    "position": {
+                        "latitude": -36.91629333,
+                        "longitude": 174.84012333
+                    },
+                    "timestamp": 1535531303,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "5bd7073a-fe6d-0801-72a2-ea18af653fb6",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1064121025-20180815114333_v70.9",
+                        "route_id": "03302-20180815114333_v70.9",
+                        "start_time": "20:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "56BA"
+                    },
+                    "position": {
+                        "latitude": -37.001833,
+                        "longitude": 174.889567,
+                        "bearing": "168"
+                    },
+                    "timestamp": 1535531299.684,
+                    "occupancy_status": 1
+                }
+            },
+            {
+                "id": "2a96a71d-7dcd-c1d4-11a8-730a4b920067",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "477138138-20180815114333_v70.9",
+                        "route_id": "07702-20180815114333_v70.9",
+                        "start_time": "20:10:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "2CAC"
+                    },
+                    "position": {
+                        "latitude": -36.850833,
+                        "longitude": 174.846367,
+                        "bearing": "97"
+                    },
+                    "timestamp": 1535531301.589,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "35fa21e7-1c44-778a-a6b9-f8bfbfe063b4",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "8301134744-20180815114333_v70.9",
+                        "route_id": "30014-20180815114333_v70.9",
+                        "start_time": "19:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "6225"
+                    },
+                    "position": {
+                        "latitude": -36.98056167,
+                        "longitude": 174.79059167
+                    },
+                    "timestamp": 1535531296
+                }
+            },
+            {
+                "id": "35440ea2-883d-c6d3-6acf-df0bb86c9949",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "470145951-20180815114333_v70.9",
+                        "route_id": "02504-20180815114333_v70.9",
+                        "start_time": "20:20:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "2CC9"
+                    },
+                    "position": {
+                        "latitude": -36.865833,
+                        "longitude": 174.761367,
+                        "bearing": "138"
+                    },
+                    "timestamp": 1535531276.688,
+                    "occupancy_status": 2
+                }
+            },
+            {
+                "id": "be34f931-d701-7f91-4182-b1fe9f623818",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1062109441-20180815114333_v70.9",
+                        "route_id": "03101-20180815114333_v70.9",
+                        "start_time": "19:55:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "6649"
+                    },
+                    "position": {
+                        "latitude": -36.942883,
+                        "longitude": 174.9126,
+                        "bearing": "79"
+                    },
+                    "timestamp": 1535531300.031,
+                    "occupancy_status": 1
+                }
+            },
+            {
+                "id": "94052d0c-dc60-258f-92df-f822f3dd2b40",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "442138074-20180815114333_v70.9",
+                        "route_id": "07502-20180815114333_v70.9",
+                        "start_time": "19:45:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "2C8C"
+                    },
+                    "position": {
+                        "latitude": -36.867917,
+                        "longitude": 174.8482,
+                        "bearing": "143"
+                    },
+                    "timestamp": 1535531295.005,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "ff6fffd1-2508-2e25-16e5-605427270f32",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "464138135-20180815114333_v70.9",
+                        "route_id": "02203-20180815114333_v70.9",
+                        "start_time": "20:07:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "2CCB"
+                    },
+                    "position": {
+                        "latitude": -36.867683,
+                        "longitude": 174.755583,
+                        "bearing": "48"
+                    },
+                    "timestamp": 1535531302.87,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "46ba73a7-8bee-4e34-ad59-41171313cd0f",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "4955094730-20180815114333_v70.9",
+                        "route_id": "95501-20180815114333_v70.9",
+                        "start_time": "20:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5214"
+                    },
+                    "position": {
+                        "latitude": -36.83014162,
+                        "longitude": 174.74606171
+                    },
+                    "timestamp": 1535531257,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "d2f41ac9-a312-c088-d1a0-90dc6c48118b",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1130125178-20180815114333_v70.9",
+                        "route_id": "19507-20180815114333_v70.9",
+                        "start_time": "19:15:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "57FA"
+                    },
+                    "position": {
+                        "latitude": -36.8651,
+                        "longitude": 174.59232167
+                    },
+                    "timestamp": 1535531229
+                }
+            },
+            {
+                "id": "956e9b0f-ab5e-7652-e240-a5b6509ab1a4",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1141102773-20180815114333_v70.9",
+                        "route_id": "07005-20180815114333_v70.9",
+                        "start_time": "20:15:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5EBB"
+                    },
+                    "position": {
+                        "latitude": -36.90015,
+                        "longitude": 174.855383,
+                        "bearing": "296"
+                    },
+                    "timestamp": 1535531302.043,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "938dc311-fde9-f174-7d50-a2f69c262c4d",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "473143323-20180815114333_v70.9",
+                        "route_id": "02702-20180815114333_v70.9",
+                        "start_time": "20:20:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "377E"
+                    },
+                    "position": {
+                        "latitude": -36.850217,
+                        "longitude": 174.772417,
+                        "bearing": "220"
+                    },
+                    "timestamp": 1535531278.94,
+                    "occupancy_status": 2
+                }
+            },
+            {
+                "id": "b03c945f-a189-6061-2970-61659225445a",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "4973089163-20180815114333_v70.9",
+                        "route_id": "97301-20180815114333_v70.9",
+                        "start_time": "20:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "521F"
+                    },
+                    "position": {
+                        "latitude": -36.82463796,
+                        "longitude": 174.74970462
+                    },
+                    "timestamp": 1535531303,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "b4b36479-75ba-13aa-6103-5ca2c4ebee58",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "439138172-20180815114333_v70.9",
+                        "route_id": "03008-20180815114333_v70.9",
+                        "start_time": "20:25:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "2CB7"
+                    },
+                    "position": {
+                        "latitude": -36.851033,
+                        "longitude": 174.76235,
+                        "bearing": "220"
+                    },
+                    "timestamp": 1535531298.495,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "108fc046-0c3d-b810-db59-2186f740f44e",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "8301134757-20180815114333_v70.9",
+                        "route_id": "30014-20180815114333_v70.9",
+                        "start_time": "19:30:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "6229"
+                    },
+                    "position": {
+                        "latitude": -36.96962,
+                        "longitude": 174.792005
+                    },
+                    "timestamp": 1535531219
+                }
+            },
+            {
+                "id": "9139b641-64e5-7b0d-053a-15c8f5f45f3e",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "475138119-20180815114333_v70.9",
+                        "route_id": "79821-20180815114333_v70.9",
+                        "start_time": "20:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "37F5"
+                    },
+                    "position": {
+                        "latitude": -36.85845,
+                        "longitude": 174.782417,
+                        "bearing": "327"
+                    },
+                    "timestamp": 1535531302,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "ecb65e63-28ad-cc6c-a26d-9751564cdadd",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1982100579-20180815114333_v70.9",
+                        "route_id": "98204-20180815114333_v70.9",
+                        "start_time": "20:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "3721"
+                    },
+                    "position": {
+                        "latitude": -36.60824818,
+                        "longitude": 174.80410531
+                    },
+                    "timestamp": 1535531304,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "f5c7bc94-b5db-7194-d240-70b3c4b0a446",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "4957089204-20180815114333_v70.9",
+                        "route_id": "95701-20180815114333_v70.9",
+                        "start_time": "20:05:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5237"
+                    },
+                    "position": {
+                        "latitude": -36.76482289,
+                        "longitude": 174.71811076
+                    },
+                    "timestamp": 1535531248,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "351fc28d-6ecb-8bb7-1ab4-7eb644685f5d",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "8300141160-20180815114333_v70.9",
+                        "route_id": "30013-20180815114333_v70.9",
+                        "start_time": "19:30:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "620A"
+                    },
+                    "position": {
+                        "latitude": -36.84989317,
+                        "longitude": 174.7611194
+                    },
+                    "timestamp": 1535531306,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "1d2e195e-39d7-5d03-1efb-afc1f553b803",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "466138156-20180815114333_v70.9",
+                        "route_id": "02404-20180815114333_v70.9",
+                        "start_time": "20:20:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "3099"
+                    },
+                    "position": {
+                        "latitude": -36.848317,
+                        "longitude": 174.769917,
+                        "bearing": "135"
+                    },
+                    "timestamp": 1535531300.345,
+                    "occupancy_status": 2
+                }
+            },
+            {
+                "id": "899f6797-1f9b-de14-d6b4-591166a3aa38",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1036125234-20180815114333_v70.9",
+                        "route_id": "18603-20180815114333_v70.9",
+                        "start_time": "20:30:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "57E6"
+                    },
+                    "position": {
+                        "latitude": -36.909433,
+                        "longitude": 174.68335,
+                        "bearing": "243"
+                    },
+                    "timestamp": 1535531267,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "e22ad6c1-e848-a109-14d2-9c0806b412f4",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "7380123832-20180815114333_v70.9",
+                        "route_id": "38014-20180815114333_v70.9",
+                        "start_time": "19:42:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "65F7"
+                    },
+                    "position": {
+                        "latitude": -36.9933,
+                        "longitude": 174.84355,
+                        "bearing": "66"
+                    },
+                    "timestamp": 1535531293.941,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "a6c4e5d8-a90d-0fcc-c59e-2122eb9a32c1",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1981089190-20180815114333_v70.9",
+                        "route_id": "98105-20180815114333_v70.9",
+                        "start_time": "20:02:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "36FE"
+                    },
+                    "position": {
+                        "latitude": -36.624267,
+                        "longitude": 174.667567,
+                        "bearing": "0"
+                    },
+                    "timestamp": 1535531002.5,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "9858f4a9-d9d2-036b-4d4c-fb107b8c50d3",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "2373143321-20180815114333_v70.9",
+                        "route_id": "37301-20180815114333_v70.9",
+                        "start_time": "20:20:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "55F5"
+                    },
+                    "position": {
+                        "latitude": -37.0661,
+                        "longitude": 174.943867,
+                        "bearing": "294"
+                    },
+                    "timestamp": 1535531287.969,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "5a62ec23-f8b4-7482-f13a-843d81fe4645",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "463138072-20180815114333_v70.9",
+                        "route_id": "02208-20180815114333_v70.9",
+                        "start_time": "19:45:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "2F58"
+                    },
+                    "position": {
+                        "latitude": -36.91362667,
+                        "longitude": 174.681365
+                    },
+                    "timestamp": 1535531297
+                }
+            },
+            {
+                "id": "3b328abc-1036-80da-bb46-f19bc76b1f4e",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1064143270-20180815114333_v70.9",
+                        "route_id": "03301-20180815114333_v70.9",
+                        "start_time": "19:10:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "590F"
+                    },
+                    "position": {
+                        "latitude": -37.03345667,
+                        "longitude": 174.91917167
+                    },
+                    "timestamp": 1535531180
+                }
+            },
+            {
+                "id": "11c5fae0-9785-a747-879e-8a4a14f393a7",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "23100144507-20180815114333_v70.9",
+                        "route_id": "820004-20180815114333_v70.9",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "AMP        334"
+                    },
+                    "position": {
+                        "latitude": -37.03401983333333,
+                        "longitude": 174.90992,
+                        "bearing": 133
+                    },
+                    "timestamp": 1535531284
+                }
+            },
+            {
+                "id": "e08f300b-a9a4-3eb1-ae25-9af8b39ceb7c",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "449138083-20180815114333_v70.9",
+                        "route_id": "29802-20180815114333_v70.9",
+                        "start_time": "19:50:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "6633"
+                    },
+                    "position": {
+                        "latitude": -36.923833,
+                        "longitude": 174.784633,
+                        "bearing": "0"
+                    },
+                    "timestamp": 1535531126.5,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "61b26362-7bd6-fe1c-15ed-332509880994",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "477138149-20180815114333_v70.9",
+                        "route_id": "07701-20180815114333_v70.9",
+                        "start_time": "20:15:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "2CAD"
+                    },
+                    "position": {
+                        "latitude": -36.849933,
+                        "longitude": 174.850683,
+                        "bearing": "256"
+                    },
+                    "timestamp": 1535531304.513,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "5626f94f-9443-2eb0-b035-755840b8035e",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "469138173-20180815114333_v70.9",
+                        "route_id": "02505-20180815114333_v70.9",
+                        "start_time": "20:25:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "2F4C"
+                    },
+                    "position": {
+                        "latitude": -36.920483,
+                        "longitude": 174.718767,
+                        "bearing": "35"
+                    },
+                    "timestamp": 1535531303.255,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "70ef06d6-5e22-8193-8ff8-6a59e90b2910",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1149102778-20180815114333_v70.9",
+                        "route_id": "07208-20180815114333_v70.9",
+                        "start_time": "20:25:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5EBA"
+                    },
+                    "position": {
+                        "latitude": -36.909783,
+                        "longitude": 174.85965,
+                        "bearing": "120"
+                    },
+                    "timestamp": 1535531299.641,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "18de20f6-cffe-54e7-b99d-e86ade40d672",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "470142075-20180815114333_v70.9",
+                        "route_id": "02503-20180815114333_v70.9",
+                        "start_time": "19:55:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "2CB3"
+                    },
+                    "position": {
+                        "latitude": -36.86115,
+                        "longitude": 174.762,
+                        "bearing": "20"
+                    },
+                    "timestamp": 1535531287.599,
+                    "occupancy_status": 1
+                }
+            },
+            {
+                "id": "bf2f701f-7b4c-3ffd-7a65-351f05bd70e3",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "471138093-20180815114333_v70.9",
+                        "route_id": "02704-20180815114333_v70.9",
+                        "start_time": "19:50:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "3A9E"
+                    },
+                    "position": {
+                        "latitude": -36.922725,
+                        "longitude": 174.734315
+                    },
+                    "timestamp": 1535531298,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "cf3b419f-ba80-2e0d-3643-90a062899ca5",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "475138163-20180815114333_v70.9",
+                        "route_id": "79821-20180815114333_v70.9",
+                        "start_time": "20:20:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "36CB"
+                    },
+                    "position": {
+                        "latitude": -36.8586,
+                        "longitude": 174.754883,
+                        "bearing": "66"
+                    },
+                    "timestamp": 1535531291.47,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "9f9c7c36-9dc0-e41a-1602-dcfc45082e4b",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "14797130546-20180815114333_v70.9",
+                        "route_id": "79702-20180815114333_v70.9",
+                        "start_time": "20:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "36B9"
+                    },
+                    "position": {
+                        "latitude": -36.8499,
+                        "longitude": 174.7649,
+                        "bearing": "15"
+                    },
+                    "timestamp": 1535531288,
+                    "occupancy_status": 1
+                }
+            },
+            {
+                "id": "d6d094e0-807b-e65b-c59f-a457c3d71f9b",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "17000144503-20180815114333_v70.9",
+                        "route_id": "810002-20180815114333_v70.9",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "AMP        471"
+                    },
+                    "position": {
+                        "latitude": -36.86758,
+                        "longitude": 174.58553,
+                        "bearing": 276
+                    },
+                    "timestamp": 1535531285
+                }
+            },
+            {
+                "id": "bb083f14-bec0-9b6e-5792-85d0c6b3e911",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "471138144-20180815114333_v70.9",
+                        "route_id": "02704-20180815114333_v70.9",
+                        "start_time": "20:10:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "3BCE"
+                    },
+                    "position": {
+                        "latitude": -36.880617,
+                        "longitude": 174.761883,
+                        "bearing": "148"
+                    },
+                    "timestamp": 1535531297.497,
+                    "occupancy_status": 1
+                }
+            },
+            {
+                "id": "98783277-50c6-531a-b33f-36c2c5abcbee",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "3813100591-20180815114333_v70.9",
+                        "route_id": "81311-20180815114333_v70.9",
+                        "start_time": "20:20:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5711"
+                    },
+                    "position": {
+                        "latitude": -36.81252028,
+                        "longitude": 174.79483668
+                    },
+                    "timestamp": 1535531303,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "fe0fbcb1-86c5-0f09-da13-188c04a24b28",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "23100144320-20180815114333_v70.9",
+                        "route_id": "820001-20180815114333_v70.9",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "AMP        646"
+                    },
+                    "position": {
+                        "latitude": -36.93715,
+                        "longitude": 174.83175,
+                        "bearing": 171
+                    },
+                    "timestamp": 1535531289
+                }
+            },
+            {
+                "id": "f91a39b1-97ec-2973-ca1b-5ccb98249aeb",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "461138129-20180815114333_v70.9",
+                        "route_id": "78201-20180815114333_v70.9",
+                        "start_time": "20:05:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "6644"
+                    },
+                    "position": {
+                        "latitude": -36.866838,
+                        "longitude": 174.82070064
+                    },
+                    "timestamp": 1535531286,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "10fcad91-85db-72ef-e4be-9a5b91474440",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1064143305-20180815114333_v70.9",
+                        "route_id": "03301-20180815114333_v70.9",
+                        "start_time": "20:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "56E2"
+                    },
+                    "position": {
+                        "latitude": -36.979217,
+                        "longitude": 174.874033,
+                        "bearing": "296"
+                    },
+                    "timestamp": 1535531263.842,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "39ce9f47-a134-334a-933c-49994135667a",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "475138142-20180815114333_v70.9",
+                        "route_id": "79922-20180815114333_v70.9",
+                        "start_time": "20:10:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "36D4"
+                    },
+                    "position": {
+                        "latitude": -36.849933,
+                        "longitude": 174.774617,
+                        "bearing": "181"
+                    },
+                    "timestamp": 1535531292.964,
+                    "occupancy_status": 1
+                }
+            },
+            {
+                "id": "2d379834-a44e-8e01-c960-7ed4aecb66fd",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "470145947-20180815114333_v70.9",
+                        "route_id": "02504-20180815114333_v70.9",
+                        "start_time": "19:50:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "2A3E"
+                    },
+                    "position": {
+                        "latitude": -36.931135,
+                        "longitude": 174.73365
+                    },
+                    "timestamp": 1535531258,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "24dbb02f-b47f-1ee2-5e6e-71b0ac2bc900",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "452138056-20180815114333_v70.9",
+                        "route_id": "67012-20180815114333_v70.9",
+                        "start_time": "19:35:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "3708"
+                    },
+                    "position": {
+                        "latitude": -36.905533,
+                        "longitude": 174.686033,
+                        "bearing": "222"
+                    },
+                    "timestamp": 1535531299.736,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "06792c27-c31f-3376-cf84-204b1f9aacb0",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1080130257-20180815114333_v70.9",
+                        "route_id": "01804-20180815114333_v70.9",
+                        "start_time": "18:38:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "3BCA"
+                    },
+                    "position": {
+                        "latitude": -36.90865667,
+                        "longitude": 174.73325667
+                    },
+                    "timestamp": 1535531307
+                }
+            },
+            {
+                "id": "16c58a03-b856-94c6-ea96-daa80b17d7dd",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "4957089107-20180815114333_v70.9",
+                        "route_id": "95704-20180815114333_v70.9",
+                        "start_time": "19:35:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "523C"
+                    },
+                    "position": {
+                        "latitude": -36.84346167,
+                        "longitude": 174.76573667
+                    },
+                    "timestamp": 1535531253
+                }
+            },
+            {
+                "id": "baadf217-7241-a2af-5041-f1ef2d6bf078",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "8300141157-20180815114333_v70.9",
+                        "route_id": "30015-20180815114333_v70.9",
+                        "start_time": "19:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "6215"
+                    },
+                    "position": {
+                        "latitude": -36.987267,
+                        "longitude": 174.785683,
+                        "bearing": "171"
+                    },
+                    "timestamp": 1535531296.847,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "59fa62a6-918d-f4f5-5648-fb22b869125e",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "14323130565-20180815114333_v70.9",
+                        "route_id": "32302-20180815114333_v70.9",
+                        "start_time": "20:10:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "6636"
+                    },
+                    "position": {
+                        "latitude": -36.940583,
+                        "longitude": 174.843633,
+                        "bearing": "74"
+                    },
+                    "timestamp": 1535531288.083,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "167d276a-7376-a41b-6371-ab33ec9aba3d",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1095109482-20180815114333_v70.9",
+                        "route_id": "14602-20180815114333_v70.9",
+                        "start_time": "20:21:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5C34"
+                    },
+                    "position": {
+                        "latitude": -36.856967,
+                        "longitude": 174.628267,
+                        "bearing": "273"
+                    },
+                    "timestamp": 1535531301.88,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "325b929d-70ff-f599-f580-7b38e3720adf",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "449138158-20180815114333_v70.9",
+                        "route_id": "29802-20180815114333_v70.9",
+                        "start_time": "20:20:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "667D"
+                    },
+                    "position": {
+                        "latitude": -36.911367,
+                        "longitude": 174.818217,
+                        "bearing": "212"
+                    },
+                    "timestamp": 1535531279.44,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "a0bd8cec-863f-4bbb-56c6-3513d8cb7959",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "14314105512-20180815114333_v70.9",
+                        "route_id": "31404-20180815114333_v70.9",
+                        "start_time": "19:46:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "6666"
+                    },
+                    "position": {
+                        "latitude": -36.9738,
+                        "longitude": 174.789235
+                    },
+                    "timestamp": 1535531279
+                }
+            },
+            {
+                "id": "9ac2fadf-0b47-4307-e442-2f8d653f6d97",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "3803089255-20180815114333_v70.9",
+                        "route_id": "80305-20180815114333_v70.9",
+                        "start_time": "20:25:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5837"
+                    },
+                    "position": {
+                        "latitude": -36.812933,
+                        "longitude": 174.780117,
+                        "bearing": "56"
+                    },
+                    "timestamp": 1535531300.708,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "f78c7edc-208f-a5a6-a488-52a901677da1",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1983053864-20180815114333_v70.9",
+                        "route_id": "98301-20180815114333_v70.9",
+                        "start_time": "19:45:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "3702"
+                    },
+                    "position": {
+                        "latitude": -36.624267,
+                        "longitude": 174.667567,
+                        "bearing": "168"
+                    },
+                    "timestamp": 1535531294,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "a110e153-aead-1341-53f8-7031e54f0789",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1082125225-20180815114333_v70.9",
+                        "route_id": "11101-20180815114333_v70.9",
+                        "start_time": "20:15:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5A3E"
+                    },
+                    "position": {
+                        "latitude": -36.829117,
+                        "longitude": 174.622883,
+                        "bearing": "197"
+                    },
+                    "timestamp": 1535531299.14,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "22ea792d-c3b7-2770-dec9-507758870e4c",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1080130332-20180815114333_v70.9",
+                        "route_id": "01804-20180815114333_v70.9",
+                        "start_time": "18:56:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "3BC7"
+                    },
+                    "position": {
+                        "latitude": -36.90807833,
+                        "longitude": 174.732165
+                    },
+                    "timestamp": 1535531157
+                }
+            },
+            {
+                "id": "e081a1a6-fcd6-76a3-0b91-847f3de83f68",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "2365143320-20180815114333_v70.9",
+                        "route_id": "36503-20180815114333_v70.9",
+                        "start_time": "20:20:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "55F9"
+                    },
+                    "position": {
+                        "latitude": -37.0416663,
+                        "longitude": 174.92485232
+                    },
+                    "timestamp": 1535531287,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "fee35a7e-c5e7-d803-19a5-6f61f9ec73a3",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "475138191-20180815114333_v70.9",
+                        "route_id": "79922-20180815114333_v70.9",
+                        "start_time": "20:30:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "37F8"
+                    },
+                    "position": {
+                        "latitude": -36.84805,
+                        "longitude": 174.753767
+                    },
+                    "timestamp": 1535531200,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "5c76d5ca-6780-cb22-104d-d8d65c9293f6",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "2391143319-20180815114333_v70.9",
+                        "route_id": "39104-20180815114333_v70.9",
+                        "start_time": "20:16:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "56FF"
+                    },
+                    "position": {
+                        "latitude": -37.199567,
+                        "longitude": 174.901317,
+                        "bearing": "181"
+                    },
+                    "timestamp": 1535531296.86,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "9cb7a9ad-1b1f-153a-288c-60d547a2a604",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "3922117487-20180815114333_v70.9",
+                        "route_id": "92202-20180815114333_v70.9",
+                        "start_time": "19:45:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "58E8"
+                    },
+                    "position": {
+                        "latitude": -36.79211,
+                        "longitude": 174.77465333
+                    },
+                    "timestamp": 1535531293,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "af1401f9-db7c-f867-9e79-78222c9edb5e",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1982100595-20180815114333_v70.9",
+                        "route_id": "98203-20180815114333_v70.9",
+                        "start_time": "20:25:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "3759"
+                    },
+                    "position": {
+                        "latitude": -36.603683,
+                        "longitude": 174.802233,
+                        "bearing": "281"
+                    },
+                    "timestamp": 1535531293.517,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "649ab040-83b4-ae35-361f-75301b38ff11",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "2371143314-20180815114333_v70.9",
+                        "route_id": "37101-20180815114333_v70.9",
+                        "start_time": "20:10:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "56DC"
+                    },
+                    "position": {
+                        "latitude": -37.06522167,
+                        "longitude": 174.94610167
+                    },
+                    "timestamp": 1535531309,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "229f7c6d-3bce-2975-1550-7292fad13c75",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "7380123834-20180815114333_v70.9",
+                        "route_id": "38013-20180815114333_v70.9",
+                        "start_time": "20:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "65F5"
+                    },
+                    "position": {
+                        "latitude": -37.004283,
+                        "longitude": 174.786517,
+                        "bearing": "250"
+                    },
+                    "timestamp": 1535531293.987,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "52b352d7-7076-8d37-8c12-ac86d69c40ee",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1141102763-20180815114333_v70.9",
+                        "route_id": "07005-20180815114333_v70.9",
+                        "start_time": "20:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5ED0"
+                    },
+                    "position": {
+                        "latitude": -36.89073072,
+                        "longitude": 174.7944125
+                    },
+                    "timestamp": 1535531296,
+                    "occupancy_status": 1
+                }
+            },
+            {
+                "id": "5f5a1d5b-6b65-58c5-7125-a18d62392f5c",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1146102741-20180815114333_v70.9",
+                        "route_id": "71102-20180815114333_v70.9",
+                        "start_time": "19:35:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "6628"
+                    },
+                    "position": {
+                        "latitude": -36.95011833,
+                        "longitude": 174.89982667
+                    },
+                    "timestamp": 1535531252
+                }
+            },
+            {
+                "id": "58fec394-bb9b-16d0-5399-fa5b1791dbff",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1096125192-20180815114333_v70.9",
+                        "route_id": "15202-20180815114333_v70.9",
+                        "start_time": "19:30:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5C33"
+                    },
+                    "position": {
+                        "latitude": -36.880617,
+                        "longitude": 174.631133,
+                        "bearing": "355"
+                    },
+                    "timestamp": 1535531277,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "ed043ab4-dd8a-e70f-92db-6ff8124028e0",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "12839117516-20180815114333_v70.9",
+                        "route_id": "83902-20180815114333_v70.9",
+                        "start_time": "20:05:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "3756"
+                    },
+                    "position": {
+                        "latitude": -36.785383,
+                        "longitude": 174.773167,
+                        "bearing": "10"
+                    },
+                    "timestamp": 1535531293.783,
+                    "occupancy_status": 2
+                }
+            },
+            {
+                "id": "a215ff8d-bc04-eb3c-f2ca-8c4f1257ac54",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "12843097374-20180815114333_v70.9",
+                        "route_id": "84302-20180815114333_v70.9",
+                        "start_time": "20:05:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "3744"
+                    },
+                    "position": {
+                        "latitude": -36.75164333,
+                        "longitude": 174.72783333
+                    },
+                    "timestamp": 1535531267,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "8fd1264d-7784-8c03-d104-5c540c925b11",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "442138107-20180815114333_v70.9",
+                        "route_id": "07501-20180815114333_v70.9",
+                        "start_time": "20:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "2C95"
+                    },
+                    "position": {
+                        "latitude": -36.851567,
+                        "longitude": 174.765867,
+                        "bearing": "317"
+                    },
+                    "timestamp": 1535531304.224,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "164b0b7f-64ce-e1ba-440c-f7cd95be81a2",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "3922117507-20180815114333_v70.9",
+                        "route_id": "92203-20180815114333_v70.9",
+                        "start_time": "20:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5815"
+                    },
+                    "position": {
+                        "latitude": -36.823533,
+                        "longitude": 174.750333,
+                        "bearing": "204"
+                    },
+                    "timestamp": 1535531297.219,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "c4b1e760-5725-1300-03eb-c0312dbf4e6c",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "7380123833-20180815114333_v70.9",
+                        "route_id": "38014-20180815114333_v70.9",
+                        "start_time": "19:57:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "6601"
+                    },
+                    "position": {
+                        "latitude": -37.00611054,
+                        "longitude": 174.79147702
+                    },
+                    "timestamp": 1535531122,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "41472560-825a-e487-ddbf-cba7ed6ff176",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1093125235-20180815114333_v70.9",
+                        "route_id": "14205-20180815114333_v70.9",
+                        "start_time": "20:30:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5AA1"
+                    },
+                    "position": {
+                        "latitude": -36.880617,
+                        "longitude": 174.631133
+                    },
+                    "timestamp": 1535531228,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "eb22cb22-a010-bcdc-d4eb-4eb54e80264a",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "8300141158-20180815114333_v70.9",
+                        "route_id": "30005-20180815114333_v70.9",
+                        "start_time": "19:15:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "6218"
+                    },
+                    "position": {
+                        "latitude": -36.95476833,
+                        "longitude": 174.79073
+                    },
+                    "timestamp": 1535531218
+                }
+            },
+            {
+                "id": "985929bd-e930-0ed7-6fa3-2238ebe763d8",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "444143322-20180815114333_v70.9",
+                        "route_id": "10502-20180815114333_v70.9",
+                        "start_time": "20:20:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "36F7"
+                    },
+                    "position": {
+                        "latitude": -36.859367,
+                        "longitude": 174.75195,
+                        "bearing": "299"
+                    },
+                    "timestamp": 1535531309.934,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "ee1c635e-1a68-8a0e-d0b1-eff6dc1d1ec2",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "476138062-20180815114333_v70.9",
+                        "route_id": "72113-20180815114333_v70.9",
+                        "start_time": "19:39:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "37E8"
+                    },
+                    "position": {
+                        "latitude": -36.893383,
+                        "longitude": 174.77445,
+                        "bearing": "87"
+                    },
+                    "timestamp": 1535531300.401,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "325bdfc7-5b4b-9e85-8cda-03e383717060",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "466138081-20180815114333_v70.9",
+                        "route_id": "02404-20180815114333_v70.9",
+                        "start_time": "19:50:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "2F55"
+                    },
+                    "position": {
+                        "latitude": -36.907133,
+                        "longitude": 174.7135,
+                        "bearing": "250"
+                    },
+                    "timestamp": 1535531302,
+                    "occupancy_status": 1
+                }
+            },
+            {
+                "id": "216a2d8c-0d85-b5e0-346d-aa6b09df491b",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "18028100573-20180815114333_v70.9",
+                        "route_id": "00104-20180815114333_v70.9",
+                        "start_time": "19:55:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "7D9C"
+                    },
+                    "position": {
+                        "latitude": -36.787155,
+                        "longitude": 175.07256333
+                    },
+                    "timestamp": 1535531162,
+                    "occupancy_status": 1
+                }
+            },
+            {
+                "id": "ae297ee4-8e80-21e1-2f75-1e8ef1333140",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "445141515-20180815114333_v70.9",
+                        "route_id": "10601-20180815114333_v70.9",
+                        "start_time": "20:05:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "36BB"
+                    },
+                    "position": {
+                        "latitude": -36.84463605,
+                        "longitude": 174.76641303
+                    },
+                    "timestamp": 1535531133,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "3aa1f0aa-3bb1-8d1a-07f5-300685451db3",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1141102655-20180815114333_v70.9",
+                        "route_id": "07006-20180815114333_v70.9",
+                        "start_time": "18:20:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5ECE"
+                    },
+                    "position": {
+                        "latitude": -36.93012333,
+                        "longitude": 174.91203667
+                    },
+                    "timestamp": 1535531292
+                }
+            },
+            {
+                "id": "ba51cf45-ea91-a9c1-2f77-af8309a5899d",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1083097375-20180815114333_v70.9",
+                        "route_id": "11201-20180815114333_v70.9",
+                        "start_time": "20:05:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5A47"
+                    },
+                    "position": {
+                        "latitude": -36.82388,
+                        "longitude": 174.60969333
+                    },
+                    "timestamp": 1535531291,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "7cdfe4c0-3dbc-aa7f-99df-356ffd6d7e5e",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1150102765-20180815114333_v70.9",
+                        "route_id": "07209-20180815114333_v70.9",
+                        "start_time": "20:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5EC2"
+                    },
+                    "position": {
+                        "latitude": -36.911783,
+                        "longitude": 174.871767,
+                        "bearing": "227"
+                    },
+                    "timestamp": 1535531291.871,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "dbb646d3-22af-eaed-8b8e-cec5628f8fc6",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "17000144146-20180815114333_v70.9",
+                        "route_id": "810003-20180815114333_v70.9",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "AMP        319"
+                    },
+                    "position": {
+                        "latitude": -36.99931,
+                        "longitude": 174.86117,
+                        "bearing": 145
+                    },
+                    "timestamp": 1535531194
+                }
+            },
+            {
+                "id": "f537f14e-8943-848a-3c93-ef82372cbddc",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1983053907-20180815114333_v70.9",
+                        "route_id": "98302-20180815114333_v70.9",
+                        "start_time": "20:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "37EE"
+                    },
+                    "position": {
+                        "latitude": -36.613367,
+                        "longitude": 174.7754,
+                        "bearing": "56"
+                    },
+                    "timestamp": 1535531303.785,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "d58816a2-758d-83c4-0212-ce0b3c0f71b3",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1120108948-20180815114333_v70.9",
+                        "route_id": "12504-20180815114333_v70.9",
+                        "start_time": "16:55:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "3785"
+                    },
+                    "position": {
+                        "latitude": -36.62565167,
+                        "longitude": 174.50205333
+                    },
+                    "timestamp": 1535531300
+                }
+            },
+            {
+                "id": "b3937c22-4b6f-1cfb-53eb-79beaa63b84d",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "460138106-20180815114333_v70.9",
+                        "route_id": "78104-20180815114333_v70.9",
+                        "start_time": "20:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "377F"
+                    },
+                    "position": {
+                        "latitude": -36.86637,
+                        "longitude": 174.84493
+                    },
+                    "timestamp": 1535531251
+                }
+            },
+            {
+                "id": "bd8eef32-d748-a1e9-f005-7aaaf0e6af10",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "2353121047-20180815114333_v70.9",
+                        "route_id": "35304-20180815114333_v70.9",
+                        "start_time": "20:20:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5E62"
+                    },
+                    "position": {
+                        "latitude": -36.965083,
+                        "longitude": 174.887733,
+                        "bearing": "192"
+                    },
+                    "timestamp": 1535531303.384,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "4fc486cd-19d9-0dfa-9d47-c12343738173",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1094125231-20180815114333_v70.9",
+                        "route_id": "14301-20180815114333_v70.9",
+                        "start_time": "20:25:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5A2C"
+                    },
+                    "position": {
+                        "latitude": -36.876517,
+                        "longitude": 174.597133,
+                        "bearing": "174"
+                    },
+                    "timestamp": 1535531307.116,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "bc7b7858-554b-ca70-f889-02c06c5c1e19",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1063122849-20180815114333_v70.9",
+                        "route_id": "03202-20180815114333_v70.9",
+                        "start_time": "19:30:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "6731"
+                    },
+                    "position": {
+                        "latitude": -36.98035,
+                        "longitude": 174.773475
+                    },
+                    "timestamp": 1535531276
+                }
+            },
+            {
+                "id": "20b4575a-0216-b550-2e5e-11e1285815ba",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "444143307-20180815114333_v70.9",
+                        "route_id": "10502-20180815114333_v70.9",
+                        "start_time": "20:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "36E6"
+                    },
+                    "position": {
+                        "latitude": -36.856867,
+                        "longitude": 174.721567,
+                        "bearing": "0"
+                    },
+                    "timestamp": 1535531042.5,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "2513036a-6247-9d02-9551-6f183eaa74a3",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "23100144525-20180815114333_v70.9",
+                        "route_id": "820002-20180815114333_v70.9",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "AMP        714"
+                    },
+                    "position": {
+                        "latitude": -36.84617,
+                        "longitude": 174.77460983333333,
+                        "bearing": 284
+                    },
+                    "timestamp": 1535531282
+                }
+            },
+            {
+                "id": "1f1a3303-7f5d-b7c5-c47a-d37ec73b0df5",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "17000144519-20180815114333_v70.9",
+                        "route_id": "810008-20180815114333_v70.9",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "AMP        388"
+                    },
+                    "position": {
+                        "latitude": -36.86569,
+                        "longitude": 174.76965,
+                        "bearing": 245
+                    },
+                    "timestamp": 1535531291
+                }
+            },
+            {
+                "id": "527b7e76-69df-03a1-603d-70b063b3aaa7",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1124109417-20180815114333_v70.9",
+                        "route_id": "01408-20180815114333_v70.9",
+                        "start_time": "19:40:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "307A"
+                    },
+                    "position": {
+                        "latitude": -36.82403,
+                        "longitude": 174.60778333
+                    },
+                    "timestamp": 1535531310,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "200625d1-a1ae-5d08-b2aa-2af953a11126",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "477138171-20180815114333_v70.9",
+                        "route_id": "07702-20180815114333_v70.9",
+                        "start_time": "20:25:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "2CB8"
+                    },
+                    "position": {
+                        "latitude": -36.844283,
+                        "longitude": 174.771017,
+                        "bearing": "104"
+                    },
+                    "timestamp": 1535531293.13,
+                    "occupancy_status": 1
+                }
+            },
+            {
+                "id": "524d6355-d7a2-0443-8689-c7a9f1b9cf05",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "8301134767-20180815114333_v70.9",
+                        "route_id": "30021-20180815114333_v70.9",
+                        "start_time": "20:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "6227"
+                    },
+                    "position": {
+                        "latitude": -36.83473349,
+                        "longitude": 174.74286559
+                    },
+                    "timestamp": 1535531297,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "6f709341-f4cb-c489-2509-d63d68a0bf2a",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "439138080-20180815114333_v70.9",
+                        "route_id": "03008-20180815114333_v70.9",
+                        "start_time": "19:48:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "37F9"
+                    },
+                    "position": {
+                        "latitude": -36.92529167,
+                        "longitude": 174.79066
+                    },
+                    "timestamp": 1535531253
+                }
+            },
+            {
+                "id": "2e615a7a-801a-5f40-a91e-12c7cb1ffed9",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "475138089-20180815114333_v70.9",
+                        "route_id": "79821-20180815114333_v70.9",
+                        "start_time": "19:50:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "37F7"
+                    },
+                    "position": {
+                        "latitude": -36.844983,
+                        "longitude": 174.7679,
+                        "bearing": "284"
+                    },
+                    "timestamp": 1535531263.673,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "851d7a2e-63cb-4c8c-c8e4-685b4296232f",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1065109486-20180815114333_v70.9",
+                        "route_id": "13406-20180815114333_v70.9",
+                        "start_time": "20:25:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5C49"
+                    },
+                    "position": {
+                        "latitude": -36.851667,
+                        "longitude": 174.759917,
+                        "bearing": "199"
+                    },
+                    "timestamp": 1535531295.794,
+                    "occupancy_status": 1
+                }
+            },
+            {
+                "id": "51c4c679-790e-9a22-d608-74a2689dd97a",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "3131109483-20180815114333_v70.9",
+                        "route_id": "13105-20180815114333_v70.9",
+                        "start_time": "20:22:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5B51"
+                    },
+                    "position": {
+                        "latitude": -36.831467,
+                        "longitude": 174.652867,
+                        "bearing": "84"
+                    },
+                    "timestamp": 1535531267.865,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "68efa31c-6a94-f07c-e0b5-1658d69f5842",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "442138148-20180815114333_v70.9",
+                        "route_id": "07502-20180815114333_v70.9",
+                        "start_time": "20:15:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "2CC2"
+                    },
+                    "position": {
+                        "latitude": -36.85285,
+                        "longitude": 174.769417,
+                        "bearing": "217"
+                    },
+                    "timestamp": 1535531274.294,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "ac166d13-6580-fdc8-802c-d8fe49b25ef9",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "4975089179-20180815114333_v70.9",
+                        "route_id": "97501-20180815114333_v70.9",
+                        "start_time": "20:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "523D"
+                    },
+                    "position": {
+                        "latitude": -36.801117,
+                        "longitude": 174.744317,
+                        "bearing": "2"
+                    },
+                    "timestamp": 1535531295.011,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "dcbf4d63-95b4-cfb8-3e7c-869e8f276cef",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "14314105494-20180815114333_v70.9",
+                        "route_id": "31404-20180815114333_v70.9",
+                        "start_time": "19:16:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "6789"
+                    },
+                    "position": {
+                        "latitude": -36.98014,
+                        "longitude": 174.77341833
+                    },
+                    "timestamp": 1535531134
+                }
+            },
+            {
+                "id": "05891fed-8df7-d47f-95f4-864359eaf521",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "477138109-20180815114333_v70.9",
+                        "route_id": "07701-20180815114333_v70.9",
+                        "start_time": "20:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "2CAA"
+                    },
+                    "position": {
+                        "latitude": -36.84545618,
+                        "longitude": 174.76771353
+                    },
+                    "timestamp": 1535531309,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "199101bc-eb64-4564-af4e-ef7545ff35ba",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "2393143317-20180815114333_v70.9",
+                        "route_id": "39304-20180815114333_v70.9",
+                        "start_time": "20:16:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "56F0"
+                    },
+                    "position": {
+                        "latitude": -37.204017,
+                        "longitude": 174.894283,
+                        "bearing": "53"
+                    },
+                    "timestamp": 1535531301.769,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "93c55def-057a-1b72-2f98-621e7682fa7b",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "440138118-20180815114333_v70.9",
+                        "route_id": "06602-20180815114333_v70.9",
+                        "start_time": "20:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5A50"
+                    },
+                    "position": {
+                        "latitude": -36.905567,
+                        "longitude": 174.743367,
+                        "bearing": "284"
+                    },
+                    "timestamp": 1535531307.915,
+                    "occupancy_status": 1
+                }
+            },
+            {
+                "id": "86811f61-3dd1-dd2e-e1aa-ddb55a48c008",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "14313121008-20180815114333_v70.9",
+                        "route_id": "31303-20180815114333_v70.9",
+                        "start_time": "19:45:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "6659"
+                    },
+                    "position": {
+                        "latitude": -36.9795,
+                        "longitude": 174.8544,
+                        "bearing": "81"
+                    },
+                    "timestamp": 1535531263.042,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "c66ab808-b08a-d1ee-a52d-960fdc9d9282",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "12839117515-20180815114333_v70.9",
+                        "route_id": "83901-20180815114333_v70.9",
+                        "start_time": "20:05:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "37EA"
+                    },
+                    "position": {
+                        "latitude": -36.733433,
+                        "longitude": 174.750333,
+                        "bearing": "212"
+                    },
+                    "timestamp": 1535531304,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "f78d0c6f-5903-6472-97dc-06ad9b0ca743",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "14323130581-20180815114333_v70.9",
+                        "route_id": "32301-20180815114333_v70.9",
+                        "start_time": "20:15:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "6629"
+                    },
+                    "position": {
+                        "latitude": -36.925767,
+                        "longitude": 174.855917,
+                        "bearing": "256"
+                    },
+                    "timestamp": 1535531298.975,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "4fb3a7c1-d73a-0616-bc5d-88406253e511",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1150102769-20180815114333_v70.9",
+                        "route_id": "07210-20180815114333_v70.9",
+                        "start_time": "20:10:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5E5C"
+                    },
+                    "position": {
+                        "latitude": -36.8931884,
+                        "longitude": 174.9419845
+                    },
+                    "timestamp": 1535531296,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "1bc3a5e1-819f-55bd-a812-b5fb344ebe52",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "4974089221-20180815114333_v70.9",
+                        "route_id": "97401-20180815114333_v70.9",
+                        "start_time": "20:15:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "522B"
+                    },
+                    "position": {
+                        "latitude": -36.806283,
+                        "longitude": 174.705883,
+                        "bearing": "84"
+                    },
+                    "timestamp": 1535531308.316,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "0bd29136-be77-9f0c-ac10-42bf4b5ef653",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1028109460-20180815114333_v70.9",
+                        "route_id": "11006-20180815114333_v70.9",
+                        "start_time": "20:05:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "3072"
+                    },
+                    "position": {
+                        "latitude": -36.850117,
+                        "longitude": 174.635583,
+                        "bearing": "299"
+                    },
+                    "timestamp": 1535531278.04,
+                    "occupancy_status": 1
+                }
+            },
+            {
+                "id": "3c52c40e-a5fb-37c6-99b5-833bb58ca209",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "475138164-20180815114333_v70.9",
+                        "route_id": "79922-20180815114333_v70.9",
+                        "start_time": "20:20:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "36D6"
+                    },
+                    "position": {
+                        "latitude": -36.8459,
+                        "longitude": 174.766217,
+                        "bearing": "0"
+                    },
+                    "timestamp": 1535531294.973,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "491172d2-5e68-59bc-a555-d13d958d97c8",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1062109354-20180815114333_v70.9",
+                        "route_id": "03101-20180815114333_v70.9",
+                        "start_time": "19:05:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "666B"
+                    },
+                    "position": {
+                        "latitude": -36.98054333,
+                        "longitude": 174.77339
+                    },
+                    "timestamp": 1535531114
+                }
+            },
+            {
+                "id": "014b0c9d-c417-f13d-f3a7-cd505b8f1de7",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "14306133936-20180815114333_v70.9",
+                        "route_id": "30901-20180815114333_v70.9",
+                        "start_time": "19:30:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "6663"
+                    },
+                    "position": {
+                        "latitude": -36.85162,
+                        "longitude": 174.76429667
+                    },
+                    "timestamp": 1535531173,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "f9453927-1dad-25ce-cae5-b47e147d23c5",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1063133941-20180815114333_v70.9",
+                        "route_id": "03201-20180815114333_v70.9",
+                        "start_time": "20:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "6604"
+                    },
+                    "position": {
+                        "latitude": -36.91523833,
+                        "longitude": 174.840075
+                    },
+                    "timestamp": 1535531300,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "4127e06e-e408-ee3e-d361-4ba767776996",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "17000144520-20180815114333_v70.9",
+                        "route_id": "810007-20180815114333_v70.9",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "AMP        144"
+                    },
+                    "position": {
+                        "latitude": -36.91154983333333,
+                        "longitude": 174.66060983333335,
+                        "bearing": 92
+                    },
+                    "timestamp": 1535531295
+                }
+            },
+            {
+                "id": "9ae628ca-16fb-63a9-b5ff-df59da7d75b9",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1141102682-20180815114333_v70.9",
+                        "route_id": "07006-20180815114333_v70.9",
+                        "start_time": "18:44:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5EA1"
+                    },
+                    "position": {
+                        "latitude": -36.92775333,
+                        "longitude": 174.90305167
+                    },
+                    "timestamp": 1535531296
+                }
+            },
+            {
+                "id": "b000d689-0789-ce59-0efc-2a6ca009432e",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "439138058-20180815114333_v70.9",
+                        "route_id": "03008-20180815114333_v70.9",
+                        "start_time": "19:36:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "30CC"
+                    },
+                    "position": {
+                        "latitude": -36.92345,
+                        "longitude": 174.784583,
+                        "bearing": "0"
+                    },
+                    "timestamp": 1535531166.5,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "72905947-5301-4be6-e660-633c55ff77d7",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "2325143311-20180815114333_v70.9",
+                        "route_id": "32503-20180815114333_v70.9",
+                        "start_time": "20:05:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "6662"
+                    },
+                    "position": {
+                        "latitude": -36.9549,
+                        "longitude": 174.8493,
+                        "bearing": "128"
+                    },
+                    "timestamp": 1535531292.329,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "d4b8792b-d7ca-1fa8-2062-b7aa58497059",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "475138120-20180815114333_v70.9",
+                        "route_id": "79922-20180815114333_v70.9",
+                        "start_time": "20:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "37F6"
+                    },
+                    "position": {
+                        "latitude": -36.86792723,
+                        "longitude": 174.77800594
+                    },
+                    "timestamp": 1535531302,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "1aca8f31-bf71-a0c2-375b-c2b6cc1dcc9d",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "464136369-20180815114333_v70.9",
+                        "route_id": "02204-20180815114333_v70.9",
+                        "start_time": "11:55:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "2F64"
+                    },
+                    "position": {
+                        "latitude": -36.895805,
+                        "longitude": 174.646035
+                    },
+                    "timestamp": 1535531294
+                }
+            },
+            {
+                "id": "e3b6bf48-5ba4-89de-7a86-8364dfaca346",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1149102776-20180815114333_v70.9",
+                        "route_id": "07207-20180815114333_v70.9",
+                        "start_time": "20:19:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5E6F"
+                    },
+                    "position": {
+                        "latitude": -36.90875,
+                        "longitude": 174.92875,
+                        "bearing": "35"
+                    },
+                    "timestamp": 1535531285.025,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "cb47a0c1-8837-90d6-99b1-490093daec46",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "464138146-20180815114333_v70.9",
+                        "route_id": "02204-20180815114333_v70.9",
+                        "start_time": "20:15:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "37BF"
+                    },
+                    "position": {
+                        "latitude": -36.858417,
+                        "longitude": 174.763567,
+                        "bearing": "204"
+                    },
+                    "timestamp": 1535531307.64,
+                    "occupancy_status": 2
+                }
+            },
+            {
+                "id": "f69d6a75-b093-3889-54c5-26599bec2b23",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "4955089135-20180815114333_v70.9",
+                        "route_id": "95504-20180815114333_v70.9",
+                        "start_time": "19:45:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5213"
+                    },
+                    "position": {
+                        "latitude": -36.77965,
+                        "longitude": 174.707317,
+                        "bearing": "48"
+                    },
+                    "timestamp": 1535531259.637,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "e1e8b7dd-7f33-7477-0bba-161c992223ea",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1130125226-20180815114333_v70.9",
+                        "route_id": "19507-20180815114333_v70.9",
+                        "start_time": "20:15:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "57FB"
+                    },
+                    "position": {
+                        "latitude": -36.930433,
+                        "longitude": 174.679617,
+                        "bearing": "71"
+                    },
+                    "timestamp": 1535531304.711,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "ea5d1a51-7b83-12da-9f89-eb7e63b23e21",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "2376143325-20180815114333_v70.9",
+                        "route_id": "37602-20180815114333_v70.9",
+                        "start_time": "20:22:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "56FE"
+                    },
+                    "position": {
+                        "latitude": -37.076667,
+                        "longitude": 174.942567,
+                        "bearing": "181"
+                    },
+                    "timestamp": 1535531306,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "3ddf838a-672b-12d7-2ec9-25316263750c",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "14313121019-20180815114333_v70.9",
+                        "route_id": "31304-20180815114333_v70.9",
+                        "start_time": "20:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "6728"
+                    },
+                    "position": {
+                        "latitude": -36.96890915,
+                        "longitude": 174.79979093
+                    },
+                    "timestamp": 1535531266,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "0f3dbe68-f2e7-00df-3007-5f9b87345335",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "470145939-20180815114333_v70.9",
+                        "route_id": "02504-20180815114333_v70.9",
+                        "start_time": "19:10:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "2F74"
+                    },
+                    "position": {
+                        "latitude": -36.82325833,
+                        "longitude": 174.61070167
+                    },
+                    "timestamp": 1535531264
+                }
+            },
+            {
+                "id": "93534a32-436c-1f13-fa51-f7c193b2f5d6",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1141102754-20180815114333_v70.9",
+                        "route_id": "07006-20180815114333_v70.9",
+                        "start_time": "19:50:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5ECF"
+                    },
+                    "position": {
+                        "latitude": -36.911883,
+                        "longitude": 174.869267,
+                        "bearing": "74"
+                    },
+                    "timestamp": 1535531299.577,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "4505717a-3d68-e2d4-80b4-51f1df393d89",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "23100144515-20180815114333_v70.9",
+                        "route_id": "820002-20180815114333_v70.9",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "AMP        428"
+                    },
+                    "position": {
+                        "latitude": -36.96284,
+                        "longitude": 174.83896,
+                        "bearing": 148
+                    },
+                    "timestamp": 1535531287
+                }
+            },
+            {
+                "id": "5735e64d-0e84-8617-a1eb-d337f1b2141c",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "50051144418-20180815114333_v70.9",
+                        "route_id": "850004-20180815114333_v70.9",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "AMP        580"
+                    },
+                    "position": {
+                        "latitude": -37.00002,
+                        "longitude": 174.86119,
+                        "bearing": 161
+                    },
+                    "timestamp": 1535531277
+                }
+            },
+            {
+                "id": "6720dbc2-8747-68cf-d5cb-769b7e45ee0f",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "3100089184-20180815114333_v70.9",
+                        "route_id": "10002-20180815114333_v70.9",
+                        "start_time": "20:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5800"
+                    },
+                    "position": {
+                        "latitude": -36.751015,
+                        "longitude": 174.72633833
+                    },
+                    "timestamp": 1535531298,
+                    "occupancy_status": 1
+                }
+            },
+            {
+                "id": "582291b0-fba9-5b49-e201-0d4cf1c1a08c",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1141102751-20180815114333_v70.9",
+                        "route_id": "07005-20180815114333_v70.9",
+                        "start_time": "19:45:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5FBA"
+                    },
+                    "position": {
+                        "latitude": -36.85285,
+                        "longitude": 174.769417,
+                        "bearing": "38"
+                    },
+                    "timestamp": 1535531306.147,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "c3e8dcb4-7414-9d23-7492-65c624fd2790",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1062123385-20180815114333_v70.9",
+                        "route_id": "03102-20180815114333_v70.9",
+                        "start_time": "19:25:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "6667"
+                    },
+                    "position": {
+                        "latitude": -36.980145,
+                        "longitude": 174.773045
+                    },
+                    "timestamp": 1535531236
+                }
+            },
+            {
+                "id": "1c532d5e-a9e9-7b17-9ae0-ace81c05e9bd",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1130125227-20180815114333_v70.9",
+                        "route_id": "19508-20180815114333_v70.9",
+                        "start_time": "20:15:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5651"
+                    },
+                    "position": {
+                        "latitude": -36.866467,
+                        "longitude": 174.741033,
+                        "bearing": "245"
+                    },
+                    "timestamp": 1535531297.698,
+                    "occupancy_status": 1
+                }
+            },
+            {
+                "id": "012c5047-3ba0-fc2c-3b2b-c87a34c08cab",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1151102657-20180815114333_v70.9",
+                        "route_id": "07206-20180815114333_v70.9",
+                        "start_time": "18:20:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5ECD"
+                    },
+                    "position": {
+                        "latitude": -36.927785,
+                        "longitude": 174.903015
+                    },
+                    "timestamp": 1535531189
+                }
+            },
+            {
+                "id": "4f9e43d0-027a-b575-cd0c-d78bed8e0ac6",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "473138098-20180815114333_v70.9",
+                        "route_id": "02705-20180815114333_v70.9",
+                        "start_time": "19:52:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "3A9B"
+                    },
+                    "position": {
+                        "latitude": -36.84427,
+                        "longitude": 174.76835833
+                    },
+                    "timestamp": 1535531273,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "4f927993-8834-c19e-94d8-98c36adccb5a",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "17000144461-20180815114333_v70.9",
+                        "route_id": "810002-20180815114333_v70.9",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "AMP        185"
+                    },
+                    "position": {
+                        "latitude": -36.88884983333333,
+                        "longitude": 174.63086,
+                        "bearing": 181
+                    },
+                    "timestamp": 1535531276
+                }
+            },
+            {
+                "id": "2c68c10a-01a4-d410-3462-fae3b3055d3e",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "7380123838-20180815114333_v70.9",
+                        "route_id": "38014-20180815114333_v70.9",
+                        "start_time": "20:27:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "65FC"
+                    },
+                    "position": {
+                        "latitude": -36.925283,
+                        "longitude": 174.783417,
+                        "bearing": "171"
+                    },
+                    "timestamp": 1535531289.122,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "de78db23-3b4d-284c-45a7-86b2486aa9e0",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "4955089228-20180815114333_v70.9",
+                        "route_id": "95504-20180815114333_v70.9",
+                        "start_time": "20:15:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5241"
+                    },
+                    "position": {
+                        "latitude": -36.81,
+                        "longitude": 174.72545,
+                        "bearing": "266"
+                    },
+                    "timestamp": 1535531282.491,
+                    "occupancy_status": 1
+                }
+            },
+            {
+                "id": "3841675c-7d8b-fb7e-22d7-682305d15a15",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "466138137-20180815114333_v70.9",
+                        "route_id": "02403-20180815114333_v70.9",
+                        "start_time": "20:10:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "37CD"
+                    },
+                    "position": {
+                        "latitude": -36.896567,
+                        "longitude": 174.733783,
+                        "bearing": "30"
+                    },
+                    "timestamp": 1535531304.057,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "666ae065-b361-4418-436b-0b8af3cd13d4",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1124109253-20180815114333_v70.9",
+                        "route_id": "01405-20180815114333_v70.9",
+                        "start_time": "18:26:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "3097"
+                    },
+                    "position": {
+                        "latitude": -36.8689,
+                        "longitude": 174.61440333
+                    },
+                    "timestamp": 1535531257
+                }
+            },
+            {
+                "id": "c3221a96-c5bc-b70d-c613-a18c79e88df9",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "438138139-20180815114333_v70.9",
+                        "route_id": "02006-20180815114333_v70.9",
+                        "start_time": "20:10:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "2CB5"
+                    },
+                    "position": {
+                        "latitude": -36.88265,
+                        "longitude": 174.731717,
+                        "bearing": "38"
+                    },
+                    "timestamp": 1535531300.262,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "2b5f06de-4a0d-7db0-0ece-7608a351a061",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "50051144516-20180815114333_v70.9",
+                        "route_id": "850001-20180815114333_v70.9",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "AMP        266"
+                    },
+                    "position": {
+                        "latitude": -36.87911,
+                        "longitude": 174.85414,
+                        "bearing": 345
+                    },
+                    "timestamp": 1535531293
+                }
+            },
+            {
+                "id": "02186d16-47f0-9e82-69ef-6a9b9eaae224",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "2352130275-20180815114333_v70.9",
+                        "route_id": "35204-20180815114333_v70.9",
+                        "start_time": "18:45:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5E6A"
+                    },
+                    "position": {
+                        "latitude": -36.934815,
+                        "longitude": 174.912825
+                    },
+                    "timestamp": 1535531176
+                }
+            },
+            {
+                "id": "f23fea4f-051d-18a3-c7e6-997dc6d1e0d9",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "469138133-20180815114333_v70.9",
+                        "route_id": "02505-20180815114333_v70.9",
+                        "start_time": "20:05:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "2C89"
+                    },
+                    "position": {
+                        "latitude": -36.873467,
+                        "longitude": 174.759083,
+                        "bearing": "104"
+                    },
+                    "timestamp": 1535531299.49,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "f684c185-2c5f-05bb-f18b-e933999a74d9",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "475138090-20180815114333_v70.9",
+                        "route_id": "79922-20180815114333_v70.9",
+                        "start_time": "19:50:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "36CC"
+                    },
+                    "position": {
+                        "latitude": -36.857667,
+                        "longitude": 174.748817,
+                        "bearing": "302"
+                    },
+                    "timestamp": 1535531303,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "3163993e-770b-724c-c715-ef63b90b3a7a",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "476138063-20180815114333_v70.9",
+                        "route_id": "73112-20180815114333_v70.9",
+                        "start_time": "19:39:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "37E3"
+                    },
+                    "position": {
+                        "latitude": -36.848233,
+                        "longitude": 174.731017,
+                        "bearing": "43"
+                    },
+                    "timestamp": 1535531302.847,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "a52477de-d952-fa96-56fc-627434b1f3fc",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "3100089182-20180815114333_v70.9",
+                        "route_id": "10001-20180815114333_v70.9",
+                        "start_time": "20:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5637"
+                    },
+                    "position": {
+                        "latitude": -36.843965,
+                        "longitude": 174.76552167
+                    },
+                    "timestamp": 1535531141,
+                    "occupancy_status": 1
+                }
+            },
+            {
+                "id": "19660816-6d20-0d3b-ba7f-fbc01defc93b",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "440138043-20180815114333_v70.9",
+                        "route_id": "06602-20180815114333_v70.9",
+                        "start_time": "19:30:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5A58"
+                    },
+                    "position": {
+                        "latitude": -36.91371,
+                        "longitude": 174.74963167
+                    },
+                    "timestamp": 1535531292
+                }
+            },
+            {
+                "id": "9da27c0a-8e10-c922-d5f6-23b16daab913",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "452138155-20180815114333_v70.9",
+                        "route_id": "67011-20180815114333_v70.9",
+                        "start_time": "20:15:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "36E0"
+                    },
+                    "position": {
+                        "latitude": -36.89545,
+                        "longitude": 174.7085,
+                        "bearing": "133"
+                    },
+                    "timestamp": 1535531283.966,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "97e25b2b-b034-f2fd-3116-0f1b203b2c83",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1146102766-20180815114333_v70.9",
+                        "route_id": "71102-20180815114333_v70.9",
+                        "start_time": "20:05:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "6632"
+                    },
+                    "position": {
+                        "latitude": -36.899217,
+                        "longitude": 174.934183,
+                        "bearing": "348"
+                    },
+                    "timestamp": 1535531301.703,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "4d96a7aa-909b-d5df-5cac-9d74bc581808",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "465138094-20180815114333_v70.9",
+                        "route_id": "02201-20180815114333_v70.9",
+                        "start_time": "19:51:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "2CA5"
+                    },
+                    "position": {
+                        "latitude": -36.8502,
+                        "longitude": 174.761983,
+                        "bearing": "284"
+                    },
+                    "timestamp": 1535531299.258,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "090ae3c4-4b2f-2c19-06fd-cb52696d3e05",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "14797130572-20180815114333_v70.9",
+                        "route_id": "79702-20180815114333_v70.9",
+                        "start_time": "20:12:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "2840"
+                    },
+                    "position": {
+                        "latitude": -36.85758743,
+                        "longitude": 174.75907387
+                    },
+                    "timestamp": 1535531304,
+                    "occupancy_status": 1
+                }
+            },
+            {
+                "id": "00aeb952-99f6-4a10-dc3d-005179e2ea45",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "8300141154-20180815114333_v70.9",
+                        "route_id": "30005-20180815114333_v70.9",
+                        "start_time": "18:30:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "6212"
+                    },
+                    "position": {
+                        "latitude": -36.980735,
+                        "longitude": 174.79036333
+                    },
+                    "timestamp": 1535531240
+                }
+            },
+            {
+                "id": "5de60988-03a5-1556-9764-b6dd9e58e4cd",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "453138166-20180815114333_v70.9",
+                        "route_id": "74302-20180815114333_v70.9",
+                        "start_time": "20:20:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "6678"
+                    },
+                    "position": {
+                        "latitude": -36.899583,
+                        "longitude": 174.853933,
+                        "bearing": "284"
+                    },
+                    "timestamp": 1535531306.906,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "8cfa15be-0aa4-a23b-7056-45fb3c246e15",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "3911089196-20180815114333_v70.9",
+                        "route_id": "91102-20180815114333_v70.9",
+                        "start_time": "20:05:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "58EB"
+                    },
+                    "position": {
+                        "latitude": -36.79738918,
+                        "longitude": 174.73039671
+                    },
+                    "timestamp": 1535531303,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "b7b16957-e0aa-801a-9683-dcace5011ed6",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1123109484-20180815114333_v70.9",
+                        "route_id": "01401-20180815114333_v70.9",
+                        "start_time": "20:24:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "2F48"
+                    },
+                    "position": {
+                        "latitude": -36.835383,
+                        "longitude": 174.6183,
+                        "bearing": "181"
+                    },
+                    "timestamp": 1535531298.042,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "58dc96b0-e0dc-5a01-6643-21cf3143a838",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "438138161-20180815114333_v70.9",
+                        "route_id": "02005-20180815114333_v70.9",
+                        "start_time": "20:20:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "374A"
+                    },
+                    "position": {
+                        "latitude": -36.859733,
+                        "longitude": 174.7528,
+                        "bearing": "40"
+                    },
+                    "timestamp": 1535531301.519,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "a20e48f3-6780-6829-cb69-8ed52625c153",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "470145949-20180815114333_v70.9",
+                        "route_id": "02504-20180815114333_v70.9",
+                        "start_time": "20:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "3095"
+                    },
+                    "position": {
+                        "latitude": -36.923433,
+                        "longitude": 174.734517,
+                        "bearing": "158"
+                    },
+                    "timestamp": 1535531295.539,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "b5bdb34c-4b67-cda6-987b-fc5704cbd586",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "457138076-20180815114333_v70.9",
+                        "route_id": "76202-20180815114333_v70.9",
+                        "start_time": "19:45:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "36DB"
+                    },
+                    "position": {
+                        "latitude": -36.85107833,
+                        "longitude": 174.79536667
+                    },
+                    "timestamp": 1535531292
+                }
+            },
+            {
+                "id": "010d2c67-d590-e091-3abc-0342a090dc68",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1080130527-20180815114333_v70.9",
+                        "route_id": "01803-20180815114333_v70.9",
+                        "start_time": "20:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "3AA8"
+                    },
+                    "position": {
+                        "latitude": -36.85805,
+                        "longitude": 174.7564,
+                        "bearing": "58"
+                    },
+                    "timestamp": 1535531270.972,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "35f21d3e-2002-f2a0-1aa5-1381a38c517b",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "475138190-20180815114333_v70.9",
+                        "route_id": "79821-20180815114333_v70.9",
+                        "start_time": "20:30:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "36D2"
+                    },
+                    "position": {
+                        "latitude": -36.8482,
+                        "longitude": 174.7548
+                    },
+                    "timestamp": 1535531279,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "2654e78e-8d30-95ef-fba4-56f7fdd9e056",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "8300141162-20180815114333_v70.9",
+                        "route_id": "30015-20180815114333_v70.9",
+                        "start_time": "20:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "6217"
+                    },
+                    "position": {
+                        "latitude": -36.866083,
+                        "longitude": 174.761483,
+                        "bearing": "320"
+                    },
+                    "timestamp": 1535531305.423,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "db0c83f2-aa6c-31e1-7cc6-93dfd0d7d279",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "4955089178-20180815114333_v70.9",
+                        "route_id": "95502-20180815114333_v70.9",
+                        "start_time": "20:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5242"
+                    },
+                    "position": {
+                        "latitude": -36.7742,
+                        "longitude": 174.721133,
+                        "bearing": "332"
+                    },
+                    "timestamp": 1535531300.905,
+                    "occupancy_status": 1
+                }
+            },
+            {
+                "id": "647bf449-548b-1ce1-5251-f2d6efbfe904",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "23100144517-20180815114333_v70.9",
+                        "route_id": "820001-20180815114333_v70.9",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "AMP        620"
+                    },
+                    "position": {
+                        "latitude": -36.95158,
+                        "longitude": 174.83404,
+                        "bearing": 350
+                    },
+                    "timestamp": 1535531242
+                }
+            },
+            {
+                "id": "2e3d4544-b222-bbe7-d182-55e59e1f9dcb",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "3887089224-20180815114333_v70.9",
+                        "route_id": "88705-20180815114333_v70.9",
+                        "start_time": "20:15:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "570F"
+                    },
+                    "position": {
+                        "latitude": -36.723133,
+                        "longitude": 174.71645,
+                        "bearing": "192"
+                    },
+                    "timestamp": 1535531277.159,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "f20ec240-ba0e-9a91-5e4d-dd955b5fc040",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "15324120968-20180815114333_v70.9",
+                        "route_id": "32412-20180815114333_v70.9",
+                        "start_time": "19:20:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "665F"
+                    },
+                    "position": {
+                        "latitude": -36.98060333,
+                        "longitude": 174.77333667
+                    },
+                    "timestamp": 1535531288
+                }
+            },
+            {
+                "id": "95ebcfaf-806c-c814-1ec9-2409e7a0978c",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "3945089251-20180815114333_v70.9",
+                        "route_id": "94502-20180815114333_v70.9",
+                        "start_time": "20:25:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5832"
+                    },
+                    "position": {
+                        "latitude": -36.779717,
+                        "longitude": 174.729617,
+                        "bearing": "99"
+                    },
+                    "timestamp": 1535531291.843,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "507e7c9f-1c04-b892-e34c-bf48b4bd9bf2",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "12879121045-20180815114333_v70.9",
+                        "route_id": "87901-20180815114333_v70.9",
+                        "start_time": "20:20:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "380E"
+                    },
+                    "position": {
+                        "latitude": -36.709167,
+                        "longitude": 174.7287,
+                        "bearing": "99"
+                    },
+                    "timestamp": 1535531305.5,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "42a9d6d0-558e-8155-4417-3ba3bd100318",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "7380123828-20180815114333_v70.9",
+                        "route_id": "38013-20180815114333_v70.9",
+                        "start_time": "19:25:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "65FE"
+                    },
+                    "position": {
+                        "latitude": -36.924183,
+                        "longitude": 174.784783,
+                        "bearing": "197"
+                    },
+                    "timestamp": 1535531294,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "519e9ea6-1d0d-81c7-0934-1310aba3ecf3",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "8300141151-20180815114333_v70.9",
+                        "route_id": "30013-20180815114333_v70.9",
+                        "start_time": "18:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "6213"
+                    },
+                    "position": {
+                        "latitude": -36.980525,
+                        "longitude": 174.79062167
+                    },
+                    "timestamp": 1535531177
+                }
+            },
+            {
+                "id": "13b6fb59-e9d9-7a2a-df46-fa85f46ff317",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1080130528-20180815114333_v70.9",
+                        "route_id": "01804-20180815114333_v70.9",
+                        "start_time": "20:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "3BD2"
+                    },
+                    "position": {
+                        "latitude": -36.8726,
+                        "longitude": 174.705117,
+                        "bearing": "179"
+                    },
+                    "timestamp": 1535531299.457,
+                    "occupancy_status": 1
+                }
+            },
+            {
+                "id": "604270b6-e61e-4232-645b-7557e431f161",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1152105530-20180815114333_v70.9",
+                        "route_id": "73303-20180815114333_v70.9",
+                        "start_time": "20:30:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "660C"
+                    },
+                    "position": {
+                        "latitude": -36.9325,
+                        "longitude": 174.912283
+                    },
+                    "timestamp": 1535531270,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "ec1193a3-1174-0a26-5b99-69e5b8074f5c",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1153102759-20180815114333_v70.9",
+                        "route_id": "73402-20180815114333_v70.9",
+                        "start_time": "19:55:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "6610"
+                    },
+                    "position": {
+                        "latitude": -36.9325,
+                        "longitude": 174.912283,
+                        "bearing": "0"
+                    },
+                    "timestamp": 1535531053.5,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "841bd874-891e-a981-ad4c-4f8c35ea69d7",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1080130500-20180815114333_v70.9",
+                        "route_id": "01804-20180815114333_v70.9",
+                        "start_time": "19:48:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "3BCF"
+                    },
+                    "position": {
+                        "latitude": -36.909533,
+                        "longitude": 174.684133,
+                        "bearing": "0"
+                    },
+                    "timestamp": 1535531281.5,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "977edcb8-13f6-9cb1-7eba-c1df9ffef129",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1035097357-20180815114333_v70.9",
+                        "route_id": "17205-20180815114333_v70.9",
+                        "start_time": "19:58:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5659"
+                    },
+                    "position": {
+                        "latitude": -36.90853333,
+                        "longitude": 174.68651333
+                    },
+                    "timestamp": 1535531206
+                }
+            },
+            {
+                "id": "513d2fa4-586d-7deb-3ecb-413698fe5bd4",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "448138157-20180815114333_v70.9",
+                        "route_id": "29503-20180815114333_v70.9",
+                        "start_time": "20:20:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "2CD5"
+                    },
+                    "position": {
+                        "latitude": -36.91059797,
+                        "longitude": 174.78378247
+                    },
+                    "timestamp": 1535531304,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "f8051005-2b4c-dfa9-d842-ab87c0624d6e",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "467138176-20180815114333_v70.9",
+                        "route_id": "02401-20180815114333_v70.9",
+                        "start_time": "20:30:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "307C"
+                    },
+                    "position": {
+                        "latitude": -36.90925,
+                        "longitude": 174.68375
+                    },
+                    "timestamp": 1535531129,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "8250e064-a953-bca9-57cb-8587ef32fd32",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "17000144503-20180815114333_v70.9",
+                        "route_id": "810002-20180815114333_v70.9",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "AMP        661"
+                    },
+                    "position": {
+                        "latitude": -36.86743,
+                        "longitude": 174.58462,
+                        "bearing": 276
+                    },
+                    "timestamp": 1535531289
+                }
+            },
+            {
+                "id": "ef8044c7-25aa-6cbf-b080-7010a1bf4106",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "2325143312-20180815114333_v70.9",
+                        "route_id": "32504-20180815114333_v70.9",
+                        "start_time": "20:05:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "6788"
+                    },
+                    "position": {
+                        "latitude": -36.956917,
+                        "longitude": 174.8627,
+                        "bearing": "268"
+                    },
+                    "timestamp": 1535531294.289,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "f778195f-0578-d2cb-deaf-1cb6b1147a23",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "7380123827-20180815114333_v70.9",
+                        "route_id": "38014-20180815114333_v70.9",
+                        "start_time": "19:10:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "6602"
+                    },
+                    "position": {
+                        "latitude": -36.97366,
+                        "longitude": 174.78912333
+                    },
+                    "timestamp": 1535531194
+                }
+            },
+            {
+                "id": "fd85f9c1-924e-3699-4df3-e72803e378f1",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "3880089045-20180815114333_v70.9",
+                        "route_id": "88002-20180815114333_v70.9",
+                        "start_time": "19:20:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "56AD"
+                    },
+                    "position": {
+                        "latitude": -36.74052667,
+                        "longitude": 174.71425
+                    },
+                    "timestamp": 1535531269
+                }
+            },
+            {
+                "id": "d7add36a-4adc-9804-0302-a69ed41bf077",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "18028089202-20180815114333_v70.9",
+                        "route_id": "00103-20180815114333_v70.9",
+                        "start_time": "20:05:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "7D9B"
+                    },
+                    "position": {
+                        "latitude": -36.7878,
+                        "longitude": 175.010683,
+                        "bearing": "0"
+                    },
+                    "timestamp": 1535531300.597,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "e0f34c51-0730-fac9-6690-7946404df963",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "23100144507-20180815114333_v70.9",
+                        "route_id": "820004-20180815114333_v70.9",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "AMP        674"
+                    },
+                    "position": {
+                        "latitude": -37.0304,
+                        "longitude": 174.90523,
+                        "bearing": 133
+                    },
+                    "timestamp": 1535531169
+                }
+            },
+            {
+                "id": "5780458e-e2c2-b3ae-8768-f0877d007814",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "12858117475-20180815114333_v70.9",
+                        "route_id": "85802-20180815114333_v70.9",
+                        "start_time": "19:35:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "37B9"
+                    },
+                    "position": {
+                        "latitude": -36.702817,
+                        "longitude": 174.751567,
+                        "bearing": "355"
+                    },
+                    "timestamp": 1535531304.753,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "d25ff3e1-ded9-5ef1-b0f0-dc2ea0c69899",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "2365143301-20180815114333_v70.9",
+                        "route_id": "36503-20180815114333_v70.9",
+                        "start_time": "19:50:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "55FC"
+                    },
+                    "position": {
+                        "latitude": -36.993383,
+                        "longitude": 174.879717,
+                        "bearing": "248"
+                    },
+                    "timestamp": 1535531301.486,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "5de4eea9-f4c6-4397-cf05-a9d373fb48ef",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "469145952-20180815114333_v70.9",
+                        "route_id": "02506-20180815114333_v70.9",
+                        "start_time": "20:30:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "378A"
+                    },
+                    "position": {
+                        "latitude": -36.851867,
+                        "longitude": 174.76415
+                    },
+                    "timestamp": 1535531269,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "aed79213-78d1-f47b-4b2a-19688d60acca",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "14306133945-20180815114333_v70.9",
+                        "route_id": "30902-20180815114333_v70.9",
+                        "start_time": "20:20:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "6786"
+                    },
+                    "position": {
+                        "latitude": -36.864233,
+                        "longitude": 174.7622,
+                        "bearing": "99"
+                    },
+                    "timestamp": 1535531296.944,
+                    "occupancy_status": 1
+                }
+            },
+            {
+                "id": "4ccf3ae1-7275-cb9e-ca07-32225dd55cd9",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "5361143224-20180815114333_v70.9",
+                        "route_id": "36102-20180815114333_v70.9",
+                        "start_time": "18:30:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "55F6"
+                    },
+                    "position": {
+                        "latitude": -37.06416667,
+                        "longitude": 174.94541833
+                    },
+                    "timestamp": 1535531275
+                }
+            },
+            {
+                "id": "1e88625e-c6e9-b81e-f6b0-aa2e854d4542",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1028109408-20180815114333_v70.9",
+                        "route_id": "11006-20180815114333_v70.9",
+                        "start_time": "19:35:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "2F5C"
+                    },
+                    "position": {
+                        "latitude": -36.86856,
+                        "longitude": 174.61406667
+                    },
+                    "timestamp": 1535531235
+                }
+            },
+            {
+                "id": "67377d75-c743-7860-6fa4-aab703cc1035",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1087109409-20180815114333_v70.9",
+                        "route_id": "12501-20180815114333_v70.9",
+                        "start_time": "19:35:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "372D"
+                    },
+                    "position": {
+                        "latitude": -36.79925,
+                        "longitude": 174.59635,
+                        "bearing": "171"
+                    },
+                    "timestamp": 1535531299.466,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "4abe0d6c-e93c-950a-0601-ab43e936b55f",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "4957089205-20180815114333_v70.9",
+                        "route_id": "95702-20180815114333_v70.9",
+                        "start_time": "20:05:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5245"
+                    },
+                    "position": {
+                        "latitude": -36.780733,
+                        "longitude": 174.721583,
+                        "bearing": "199"
+                    },
+                    "timestamp": 1535531305,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "25ba0939-7bd0-f154-2586-4bd9bcde04d2",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "8300141155-20180815114333_v70.9",
+                        "route_id": "30013-20180815114333_v70.9",
+                        "start_time": "18:40:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "621C"
+                    },
+                    "position": {
+                        "latitude": -36.991545,
+                        "longitude": 174.78617667
+                    },
+                    "timestamp": 1535531255
+                }
+            },
+            {
+                "id": "895d570a-77bb-dd98-cd8b-bd1a9c554e67",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1155102761-20180815114333_v70.9",
+                        "route_id": "73901-20180815114333_v70.9",
+                        "start_time": "20:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "666F"
+                    },
+                    "position": {
+                        "latitude": -36.927183,
+                        "longitude": 174.992717,
+                        "bearing": "181"
+                    },
+                    "timestamp": 1535531302.346,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "ef899536-c955-45d3-b0e4-1192a531b379",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "466138064-20180815114333_v70.9",
+                        "route_id": "02403-20180815114333_v70.9",
+                        "start_time": "19:40:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "2CB1"
+                    },
+                    "position": {
+                        "latitude": -36.84578167,
+                        "longitude": 174.756385
+                    },
+                    "timestamp": 1535531241,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "ab0535ed-9530-9bc2-22e2-db87d7091d66",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "3911089226-20180815114333_v70.9",
+                        "route_id": "91103-20180815114333_v70.9",
+                        "start_time": "20:15:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "56A6"
+                    },
+                    "position": {
+                        "latitude": -36.8026271,
+                        "longitude": 174.74349055
+                    },
+                    "timestamp": 1535531202,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "a0cb22b6-2d33-8ab9-6008-04ce26d9e890",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "469145895-20180815114333_v70.9",
+                        "route_id": "02506-20180815114333_v70.9",
+                        "start_time": "16:25:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "30CD"
+                    },
+                    "position": {
+                        "latitude": -36.92561333,
+                        "longitude": 174.79101
+                    },
+                    "timestamp": 1535531254
+                }
+            },
+            {
+                "id": "243dffa0-6209-8800-a66e-8528abd07520",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "50051144510-20180815114333_v70.9",
+                        "route_id": "850004-20180815114333_v70.9",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "AMP        618"
+                    },
+                    "position": {
+                        "latitude": -36.99441,
+                        "longitude": 174.87615,
+                        "bearing": 64
+                    },
+                    "timestamp": 1535531040
+                }
+            },
+            {
+                "id": "06b93eb7-e59c-83c1-928c-dc1a2e978461",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "3100089183-20180815114333_v70.9",
+                        "route_id": "10003-20180815114333_v70.9",
+                        "start_time": "20:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "59C3"
+                    },
+                    "position": {
+                        "latitude": -36.821167,
+                        "longitude": 174.75015,
+                        "bearing": "171"
+                    },
+                    "timestamp": 1535531299.743,
+                    "occupancy_status": 1
+                }
+            },
+            {
+                "id": "576ef2d7-388e-6112-18ad-3a18b828bce8",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "465138168-20180815114333_v70.9",
+                        "route_id": "02201-20180815114333_v70.9",
+                        "start_time": "20:21:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "30B8"
+                    },
+                    "position": {
+                        "latitude": -36.89425,
+                        "longitude": 174.7001,
+                        "bearing": "66"
+                    },
+                    "timestamp": 1535531302.215,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "d6cbe6ae-13fd-bcfa-8826-10cc056c4253",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "439138145-20180815114333_v70.9",
+                        "route_id": "03008-20180815114333_v70.9",
+                        "start_time": "20:12:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "3093"
+                    },
+                    "position": {
+                        "latitude": -36.873033,
+                        "longitude": 174.77715,
+                        "bearing": "176"
+                    },
+                    "timestamp": 1535531303,
+                    "occupancy_status": 1
+                }
+            },
+            {
+                "id": "77c304bf-227c-7c7c-ed87-b02d5dad46fd",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "2365143313-20180815114333_v70.9",
+                        "route_id": "36504-20180815114333_v70.9",
+                        "start_time": "20:05:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "55F1"
+                    },
+                    "position": {
+                        "latitude": -37.03068582,
+                        "longitude": 174.92511138
+                    },
+                    "timestamp": 1535531253,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "19607de1-1c09-0bfa-7c7b-9fe032e79f20",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "453138132-20180815114333_v70.9",
+                        "route_id": "74301-20180815114333_v70.9",
+                        "start_time": "20:05:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "6679"
+                    },
+                    "position": {
+                        "latitude": -36.907917,
+                        "longitude": 174.839017,
+                        "bearing": "25"
+                    },
+                    "timestamp": 1535531288.986,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "ff06cabb-ff6c-3476-b292-9243ffbee443",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "476138124-20180815114333_v70.9",
+                        "route_id": "73112-20180815114333_v70.9",
+                        "start_time": "20:03:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "36BF"
+                    },
+                    "position": {
+                        "latitude": -36.89316391,
+                        "longitude": 174.77451209
+                    },
+                    "timestamp": 1535531294,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "6836f8a2-62ee-bf35-c1aa-c73474bb1592",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "454138159-20180815114333_v70.9",
+                        "route_id": "74401-20180815114333_v70.9",
+                        "start_time": "20:20:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "6677"
+                    },
+                    "position": {
+                        "latitude": -36.87852667,
+                        "longitude": 174.85441854
+                    },
+                    "timestamp": 1535531305,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "c55a3e99-99b6-baa9-b522-a03e0d40f81d",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1144121035-20180815114333_v70.9",
+                        "route_id": "35505-20180815114333_v70.9",
+                        "start_time": "20:05:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5E6C"
+                    },
+                    "position": {
+                        "latitude": -36.95585,
+                        "longitude": 174.915567,
+                        "bearing": "10"
+                    },
+                    "timestamp": 1535531300.383,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "a17bf2a3-df5a-fd3c-042c-15755ff826ab",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "14797130560-20180815114333_v70.9",
+                        "route_id": "79702-20180815114333_v70.9",
+                        "start_time": "20:06:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "36B7"
+                    },
+                    "position": {
+                        "latitude": -36.853367,
+                        "longitude": 174.763517,
+                        "bearing": "20"
+                    },
+                    "timestamp": 1535531278.058,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "5466dc71-b86f-44d8-e59b-af53a4b53aa0",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1062109489-20180815114333_v70.9",
+                        "route_id": "03101-20180815114333_v70.9",
+                        "start_time": "20:25:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "6664"
+                    },
+                    "position": {
+                        "latitude": -36.966417,
+                        "longitude": 174.808517,
+                        "bearing": "56"
+                    },
+                    "timestamp": 1535531294.484,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "c6c4a632-b83d-807a-734d-dd27c767a2dd",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "451137915-20180815114333_v70.9",
+                        "route_id": "65001-20180815114333_v70.9",
+                        "start_time": "18:50:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "3731"
+                    },
+                    "position": {
+                        "latitude": -36.88037833,
+                        "longitude": 174.851585
+                    },
+                    "timestamp": 1535531270
+                }
+            },
+            {
+                "id": "41a316a1-16c6-2645-3e6c-c9486a00b710",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "8300141152-20180815114333_v70.9",
+                        "route_id": "30005-20180815114333_v70.9",
+                        "start_time": "18:10:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "621D"
+                    },
+                    "position": {
+                        "latitude": -36.98433167,
+                        "longitude": 174.79056333
+                    },
+                    "timestamp": 1535531266
+                }
+            },
+            {
+                "id": "e1a995cc-0362-a614-b326-43919f330a2b",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1063122352-20180815114333_v70.9",
+                        "route_id": "03202-20180815114333_v70.9",
+                        "start_time": "20:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "6724"
+                    },
+                    "position": {
+                        "latitude": -36.976,
+                        "longitude": 174.799833,
+                        "bearing": "263"
+                    },
+                    "timestamp": 1535531303.973,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "af59b961-7c6a-8fb3-614c-4b1ca9ad39e6",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "476138123-20180815114333_v70.9",
+                        "route_id": "72113-20180815114333_v70.9",
+                        "start_time": "20:03:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "37E1"
+                    },
+                    "position": {
+                        "latitude": -36.86887769,
+                        "longitude": 174.70917094
+                    },
+                    "timestamp": 1535531308,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "8ed8793c-daf7-5d7c-1a97-d8c03d1be6d8",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1147102750-20180815114333_v70.9",
+                        "route_id": "71203-20180815114333_v70.9",
+                        "start_time": "19:45:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "6672"
+                    },
+                    "position": {
+                        "latitude": -36.911333,
+                        "longitude": 174.872567,
+                        "bearing": "250"
+                    },
+                    "timestamp": 1535531302.721,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "af7ecfc6-a9e4-c691-8a17-ee2b4a6d76e5",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1141102746-20180815114333_v70.9",
+                        "route_id": "07006-20180815114333_v70.9",
+                        "start_time": "19:40:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5FBB"
+                    },
+                    "position": {
+                        "latitude": -36.923933,
+                        "longitude": 174.884883,
+                        "bearing": "115"
+                    },
+                    "timestamp": 1535531300.571,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "0fcf5725-41f7-feab-f6d0-f78a78973e03",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "18025089203-20180815114333_v70.9",
+                        "route_id": "00201-20180815114333_v70.9",
+                        "start_time": "20:05:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "7D96"
+                    },
+                    "position": {
+                        "latitude": -36.784983,
+                        "longitude": 175.032767,
+                        "bearing": "107"
+                    },
+                    "timestamp": 1535531262.383,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "01f0686f-0ff1-f2c6-31a5-23c27a34bf64",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "14797130459-20180815114333_v70.9",
+                        "route_id": "79702-20180815114333_v70.9",
+                        "start_time": "19:30:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "3800"
+                    },
+                    "position": {
+                        "latitude": -36.84055976,
+                        "longitude": 174.75480343
+                    },
+                    "timestamp": 1535531117,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "6509a8b3-8c67-558c-0182-295cb35e5e9e",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "12875117827-20180815114333_v70.9",
+                        "route_id": "87502-20180815114333_v70.9",
+                        "start_time": "19:50:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "372A"
+                    },
+                    "position": {
+                        "latitude": -36.755883,
+                        "longitude": 174.750867,
+                        "bearing": "353"
+                    },
+                    "timestamp": 1535531299.889,
+                    "occupancy_status": 1
+                }
+            },
+            {
+                "id": "f7dc5e69-13c1-0b9e-683f-2d5cfacd23a7",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "2353121012-20180815114333_v70.9",
+                        "route_id": "35304-20180815114333_v70.9",
+                        "start_time": "19:50:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5E65"
+                    },
+                    "position": {
+                        "latitude": -36.99362333,
+                        "longitude": 174.87934333
+                    },
+                    "timestamp": 1535531271,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "46b589d6-aae5-37c1-8f67-0b82272f0ee4",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "469145942-20180815114333_v70.9",
+                        "route_id": "02506-20180815114333_v70.9",
+                        "start_time": "19:25:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "307F"
+                    },
+                    "position": {
+                        "latitude": -36.92515833,
+                        "longitude": 174.77510167
+                    },
+                    "timestamp": 1535531289
+                }
+            },
+            {
+                "id": "9398b21a-7306-b406-dfc0-a3cfcdc36de6",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "17000144513-20180815114333_v70.9",
+                        "route_id": "810002-20180815114333_v70.9",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "AMP        362"
+                    },
+                    "position": {
+                        "latitude": -36.91142,
+                        "longitude": 174.66952,
+                        "bearing": 273
+                    },
+                    "timestamp": 1535531288
+                }
+            },
+            {
+                "id": "c5be8ec5-8acf-af69-3c7e-5c352c9333a8",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "463138134-20180815114333_v70.9",
+                        "route_id": "02208-20180815114333_v70.9",
+                        "start_time": "20:07:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "2F52"
+                    },
+                    "position": {
+                        "latitude": -36.8815,
+                        "longitude": 174.730767,
+                        "bearing": "325"
+                    },
+                    "timestamp": 1535531296.299,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "cc183aff-1d2d-e70e-4b60-7d5c14951eb8",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1081125182-20180815114333_v70.9",
+                        "route_id": "10701-20180815114333_v70.9",
+                        "start_time": "19:20:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "57F1"
+                    },
+                    "position": {
+                        "latitude": -36.86453333,
+                        "longitude": 174.59273333
+                    },
+                    "timestamp": 1535531295
+                }
+            },
+            {
+                "id": "679a28a8-8dca-cdf7-7637-64ac07b17c89",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "442138108-20180815114333_v70.9",
+                        "route_id": "07502-20180815114333_v70.9",
+                        "start_time": "20:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "30BC"
+                    },
+                    "position": {
+                        "latitude": -36.86765,
+                        "longitude": 174.778117,
+                        "bearing": "99"
+                    },
+                    "timestamp": 1535531295.219,
+                    "occupancy_status": 1
+                }
+            },
+            {
+                "id": "76c554a2-ceab-f5e1-8df9-8164114037cc",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "476138027-20180815114333_v70.9",
+                        "route_id": "73112-20180815114333_v70.9",
+                        "start_time": "19:27:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "36C5"
+                    },
+                    "position": {
+                        "latitude": -36.84805,
+                        "longitude": 174.753767,
+                        "bearing": "87"
+                    },
+                    "timestamp": 1535531304.131,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "b2980799-99cb-9820-b21a-744a0ac89c5e",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "2325143247-20180815114333_v70.9",
+                        "route_id": "32504-20180815114333_v70.9",
+                        "start_time": "18:50:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "67EE"
+                    },
+                    "position": {
+                        "latitude": -36.968983,
+                        "longitude": 174.799667,
+                        "bearing": "0"
+                    },
+                    "timestamp": 1535531309.5,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "74488f35-07c0-dac4-7096-9f3c2e0e6fdc",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "455138128-20180815114333_v70.9",
+                        "route_id": "74702-20180815114333_v70.9",
+                        "start_time": "20:05:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "6631"
+                    },
+                    "position": {
+                        "latitude": -36.89756,
+                        "longitude": 174.84955833
+                    },
+                    "timestamp": 1535531280
+                }
+            },
+            {
+                "id": "1d5fcdd4-edd6-f7a7-2cad-e6394535da70",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "467138125-20180815114333_v70.9",
+                        "route_id": "02402-20180815114333_v70.9",
+                        "start_time": "20:05:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "3086"
+                    },
+                    "position": {
+                        "latitude": -36.88515,
+                        "longitude": 174.738433,
+                        "bearing": "192"
+                    },
+                    "timestamp": 1535531305.012,
+                    "occupancy_status": 2
+                }
+            },
+            {
+                "id": "009ec601-7bb5-b094-9cbf-b56316ee4429",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1080130574-20180815114333_v70.9",
+                        "route_id": "01804-20180815114333_v70.9",
+                        "start_time": "20:15:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "3AAC"
+                    },
+                    "position": {
+                        "latitude": -36.866467,
+                        "longitude": 174.741033,
+                        "bearing": "245"
+                    },
+                    "timestamp": 1535531305.685,
+                    "occupancy_status": 1
+                }
+            },
+            {
+                "id": "18891acb-8c9c-95ac-947a-929a6ed7e8be",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "12879121046-20180815114333_v70.9",
+                        "route_id": "87902-20180815114333_v70.9",
+                        "start_time": "20:20:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "3743"
+                    },
+                    "position": {
+                        "latitude": -36.84935,
+                        "longitude": 174.758933,
+                        "bearing": "291"
+                    },
+                    "timestamp": 1535531294.11,
+                    "occupancy_status": 2
+                }
+            },
+            {
+                "id": "0e5f04bb-647b-f0ef-1971-c117fbac3ea2",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1080130573-20180815114333_v70.9",
+                        "route_id": "01803-20180815114333_v70.9",
+                        "start_time": "20:15:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "3AA9"
+                    },
+                    "position": {
+                        "latitude": -36.871317,
+                        "longitude": 174.705217,
+                        "bearing": "64"
+                    },
+                    "timestamp": 1535531303.31,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "c5de3b5d-986e-692a-fe58-24ab1bcf2687",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1124109430-20180815114333_v70.9",
+                        "route_id": "01405-20180815114333_v70.9",
+                        "start_time": "19:48:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "2F5D"
+                    },
+                    "position": {
+                        "latitude": -36.910175,
+                        "longitude": 174.681
+                    },
+                    "timestamp": 1535531292,
+                    "occupancy_status": 1
+                }
+            },
+            {
+                "id": "f30c3ef8-dc10-23a0-46da-bf50e7d8eed0",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "440138117-20180815114333_v70.9",
+                        "route_id": "06601-20180815114333_v70.9",
+                        "start_time": "20:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5A4A"
+                    },
+                    "position": {
+                        "latitude": -36.911717,
+                        "longitude": 174.775033,
+                        "bearing": "107"
+                    },
+                    "timestamp": 1535531259.946,
+                    "occupancy_status": 1
+                }
+            },
+            {
+                "id": "697a8c11-0da3-b0ae-940a-6b601b24f785",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "3100089149-20180815114333_v70.9",
+                        "route_id": "10002-20180815114333_v70.9",
+                        "start_time": "19:53:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "57D9"
+                    },
+                    "position": {
+                        "latitude": -36.72211833,
+                        "longitude": 174.71202333
+                    },
+                    "timestamp": 1535531239,
+                    "occupancy_status": 1
+                }
+            },
+            {
+                "id": "0b8e42d1-7ca9-5eea-fb23-85469db3e74c",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "51100144523-20180815114333_v70.9",
+                        "route_id": "840003-20180815114333_v70.9",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "AMP        375"
+                    },
+                    "position": {
+                        "latitude": -36.89247,
+                        "longitude": 174.8021,
+                        "bearing": 304
+                    },
+                    "timestamp": 1535531298
+                }
+            },
+            {
+                "id": "36d12c6b-f03a-0f25-5b06-806e59ff15d4",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "7380123823-20180815114333_v70.9",
+                        "route_id": "38014-20180815114333_v70.9",
+                        "start_time": "18:40:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "65FB"
+                    },
+                    "position": {
+                        "latitude": -36.99372667,
+                        "longitude": 174.87895667
+                    },
+                    "timestamp": 1535531289,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "b93e06e0-954d-398f-6c47-761d099386a2",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1084117484-20180815114333_v70.9",
+                        "route_id": "11402-20180815114333_v70.9",
+                        "start_time": "19:45:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5A45"
+                    },
+                    "position": {
+                        "latitude": -36.81460667,
+                        "longitude": 174.61346667
+                    },
+                    "timestamp": 1535531283
+                }
+            },
+            {
+                "id": "0d485fb3-0aec-a044-8a0d-969fd7ecd848",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "5361143316-20180815114333_v70.9",
+                        "route_id": "36102-20180815114333_v70.9",
+                        "start_time": "20:15:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5604"
+                    },
+                    "position": {
+                        "latitude": -36.97944863,
+                        "longitude": 174.87474456
+                    },
+                    "timestamp": 1535531309,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "cd257dc0-620b-401b-96e7-1df5d64ee862",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "470142076-20180815114333_v70.9",
+                        "route_id": "02503-20180815114333_v70.9",
+                        "start_time": "20:15:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "3080"
+                    },
+                    "position": {
+                        "latitude": -36.909033,
+                        "longitude": 174.74025,
+                        "bearing": "12"
+                    },
+                    "timestamp": 1535531295,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "c9003b3e-183f-7205-8784-94cef4508b35",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "467138104-20180815114333_v70.9",
+                        "route_id": "02401-20180815114333_v70.9",
+                        "start_time": "20:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "2CB2"
+                    },
+                    "position": {
+                        "latitude": -36.86115,
+                        "longitude": 174.762,
+                        "bearing": "25"
+                    },
+                    "timestamp": 1535531292,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "204e9562-3f4c-e03b-2817-9ab5ce017923",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "439138020-20180815114333_v70.9",
+                        "route_id": "03008-20180815114333_v70.9",
+                        "start_time": "19:24:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "2C8B"
+                    },
+                    "position": {
+                        "latitude": -36.925855,
+                        "longitude": 174.79063667
+                    },
+                    "timestamp": 1535531240
+                }
+            },
+            {
+                "id": "e5371d58-f01d-83b5-3cf1-193998732f9e",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "466138025-20180815114333_v70.9",
+                        "route_id": "02404-20180815114333_v70.9",
+                        "start_time": "19:27:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "2F75"
+                    },
+                    "position": {
+                        "latitude": -36.86854167,
+                        "longitude": 174.61406333
+                    },
+                    "timestamp": 1535531249
+                }
+            },
+            {
+                "id": "a2505b5c-805c-5543-b556-aa73c2146799",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "14392143318-20180815114333_v70.9",
+                        "route_id": "39218-20180815114333_v70.9",
+                        "start_time": "20:16:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "56E1"
+                    },
+                    "position": {
+                        "latitude": -37.203483,
+                        "longitude": 174.895367,
+                        "bearing": "128"
+                    },
+                    "timestamp": 1535531306.818,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "7dfb7322-cd51-90f4-c2f2-0ae615d85bbe",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "14797130587-20180815114333_v70.9",
+                        "route_id": "79702-20180815114333_v70.9",
+                        "start_time": "20:18:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "36B5"
+                    },
+                    "position": {
+                        "latitude": -36.85386622,
+                        "longitude": 174.76324247
+                    },
+                    "timestamp": 1535531275,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "79d027e3-fe71-e740-7b23-5211b1c9a761",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "3880089235-20180815114333_v70.9",
+                        "route_id": "88002-20180815114333_v70.9",
+                        "start_time": "20:20:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "56AA"
+                    },
+                    "position": {
+                        "latitude": -36.72217167,
+                        "longitude": 174.71328333
+                    },
+                    "timestamp": 1535531278,
+                    "occupancy_status": 1
+                }
+            },
+            {
+                "id": "57417d46-0768-701d-00ae-146e51ba4780",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "477138099-20180815114333_v70.9",
+                        "route_id": "07702-20180815114333_v70.9",
+                        "start_time": "19:55:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "2CAE"
+                    },
+                    "position": {
+                        "latitude": -36.88021333,
+                        "longitude": 174.85503833
+                    },
+                    "timestamp": 1535531116,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "da4de42a-d27f-a49b-75d4-65664f213a7b",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "453138092-20180815114333_v70.9",
+                        "route_id": "74302-20180815114333_v70.9",
+                        "start_time": "19:50:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "6676"
+                    },
+                    "position": {
+                        "latitude": -36.923683,
+                        "longitude": 174.784733,
+                        "bearing": "0"
+                    },
+                    "timestamp": 1535531191.5,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "1fa7002b-ace8-73f9-9756-55028a459017",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "3100089230-20180815114333_v70.9",
+                        "route_id": "10004-20180815114333_v70.9",
+                        "start_time": "20:15:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "57FF"
+                    },
+                    "position": {
+                        "latitude": -36.784433,
+                        "longitude": 174.750817,
+                        "bearing": "332"
+                    },
+                    "timestamp": 1535531269.427,
+                    "occupancy_status": 2
+                }
+            },
+            {
+                "id": "5a404a04-dcfe-29aa-56e6-298b09ac69c1",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "2325143289-20180815114333_v70.9",
+                        "route_id": "32503-20180815114333_v70.9",
+                        "start_time": "19:35:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "6730"
+                    },
+                    "position": {
+                        "latitude": -36.99366833,
+                        "longitude": 174.87836667
+                    },
+                    "timestamp": 1535531145,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "5ac76451-e7f1-2d4e-c5d9-19a28256c9eb",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "13154125193-20180815114333_v70.9",
+                        "route_id": "15405-20180815114333_v70.9",
+                        "start_time": "19:30:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5A4E"
+                    },
+                    "position": {
+                        "latitude": -36.90952667,
+                        "longitude": 174.68405667
+                    },
+                    "timestamp": 1535531303,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "d59cd7e9-01df-d0e0-087c-5850214dca6f",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "3131109383-20180815114333_v70.9",
+                        "route_id": "13105-20180815114333_v70.9",
+                        "start_time": "19:22:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5A4B"
+                    },
+                    "position": {
+                        "latitude": -36.91372333,
+                        "longitude": 174.74998667
+                    },
+                    "timestamp": 1535531300
+                }
+            },
+            {
+                "id": "b15bb0ff-7b13-6d7d-7aed-b06dbcc01cba",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "441138187-20180815114333_v70.9",
+                        "route_id": "06801-20180815114333_v70.9",
+                        "start_time": "20:30:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "3782"
+                    },
+                    "position": {
+                        "latitude": -36.90925,
+                        "longitude": 174.68375
+                    },
+                    "timestamp": 1535531215,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "9abb24bd-e126-357d-b13b-cbe3a76f4075",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "448138082-20180815114333_v70.9",
+                        "route_id": "29501-20180815114333_v70.9",
+                        "start_time": "19:50:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "2CBA"
+                    },
+                    "position": {
+                        "latitude": -36.865333,
+                        "longitude": 174.767267,
+                        "bearing": "281"
+                    },
+                    "timestamp": 1535531302.983,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "929ee81a-6d0d-d023-08af-c5f76ccadc85",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1988100563-20180815114333_v70.9",
+                        "route_id": "98801-20180815114333_v70.9",
+                        "start_time": "19:45:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "3700"
+                    },
+                    "position": {
+                        "latitude": -36.709515,
+                        "longitude": 174.73355833
+                    },
+                    "timestamp": 1535531299
+                }
+            },
+            {
+                "id": "b09c17a6-4929-a898-6878-d2a93808e97c",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "476138175-20180815114333_v70.9",
+                        "route_id": "73112-20180815114333_v70.9",
+                        "start_time": "20:27:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "37E4"
+                    },
+                    "position": {
+                        "latitude": -36.852533,
+                        "longitude": 174.767017,
+                        "bearing": "130"
+                    },
+                    "timestamp": 1535531302,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "656ea7ce-6b5b-91e3-b641-ac788fff9f7e",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "3922117447-20180815114333_v70.9",
+                        "route_id": "92202-20180815114333_v70.9",
+                        "start_time": "19:15:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "57E1"
+                    },
+                    "position": {
+                        "latitude": -36.74039167,
+                        "longitude": 174.71432667
+                    },
+                    "timestamp": 1535531271
+                }
+            },
+            {
+                "id": "644d4874-a5ca-a773-9abb-e52bc261f024",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "14797130600-20180815114333_v70.9",
+                        "route_id": "79702-20180815114333_v70.9",
+                        "start_time": "20:24:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "37F2"
+                    },
+                    "position": {
+                        "latitude": -36.8457416,
+                        "longitude": 174.75651073
+                    },
+                    "timestamp": 1535531291,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "57a9313e-407f-8ee1-3443-b418c139c55d",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "2372143324-20180815114333_v70.9",
+                        "route_id": "37202-20180815114333_v70.9",
+                        "start_time": "20:21:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "56F7"
+                    },
+                    "position": {
+                        "latitude": -37.0609,
+                        "longitude": 174.961533,
+                        "bearing": "76"
+                    },
+                    "timestamp": 1535531307.336,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "c620b04b-c1e8-a178-20dd-a463953b2b20",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "14323130521-20180815114333_v70.9",
+                        "route_id": "32301-20180815114333_v70.9",
+                        "start_time": "19:55:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "662F"
+                    },
+                    "position": {
+                        "latitude": -36.897455,
+                        "longitude": 174.84965333
+                    },
+                    "timestamp": 1535531283
+                }
+            },
+            {
+                "id": "1c8e544e-7389-4431-0669-db81585b49a1",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "7380123831-20180815114333_v70.9",
+                        "route_id": "38013-20180815114333_v70.9",
+                        "start_time": "19:40:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "65FA"
+                    },
+                    "position": {
+                        "latitude": -36.96435,
+                        "longitude": 174.794633,
+                        "bearing": "340"
+                    },
+                    "timestamp": 1535531301,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "b0e8ab62-c3cb-4c19-8589-9e62cab43e63",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "451138012-20180815114333_v70.9",
+                        "route_id": "65001-20180815114333_v70.9",
+                        "start_time": "19:20:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "37DE"
+                    },
+                    "position": {
+                        "latitude": -36.88011333,
+                        "longitude": 174.85492667
+                    },
+                    "timestamp": 1535531303
+                }
+            },
+            {
+                "id": "93944cdd-8f98-142e-4816-53a8b3b26b2c",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "476138095-20180815114333_v70.9",
+                        "route_id": "72113-20180815114333_v70.9",
+                        "start_time": "19:51:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "37E5"
+                    },
+                    "position": {
+                        "latitude": -36.882483,
+                        "longitude": 174.74885,
+                        "bearing": "12"
+                    },
+                    "timestamp": 1535531298.521,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "e2fa4728-2578-dbdd-8af5-454d8a198e6d",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "476138096-20180815114333_v70.9",
+                        "route_id": "73112-20180815114333_v70.9",
+                        "start_time": "19:51:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "36C6"
+                    },
+                    "position": {
+                        "latitude": -36.885483,
+                        "longitude": 174.73985,
+                        "bearing": "281"
+                    },
+                    "timestamp": 1535531288.094,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "216da537-1cc9-467a-9fcf-1f06afda6ab8",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1028109459-20180815114333_v70.9",
+                        "route_id": "11005-20180815114333_v70.9",
+                        "start_time": "20:05:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "2F7D"
+                    },
+                    "position": {
+                        "latitude": -36.86692247,
+                        "longitude": 174.73978417
+                    },
+                    "timestamp": 1535531301,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "0a925f2c-e2ef-3508-eeb7-894eb8a98f29",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "469145948-20180815114333_v70.9",
+                        "route_id": "02506-20180815114333_v70.9",
+                        "start_time": "19:55:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "2F4D"
+                    },
+                    "position": {
+                        "latitude": -36.92276659,
+                        "longitude": 174.70139342
+                    },
+                    "timestamp": 1535531183,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "c219b2dd-2644-93d1-f519-36b261f8f1ee",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "444138143-20180815114333_v70.9",
+                        "route_id": "10501-20180815114333_v70.9",
+                        "start_time": "20:10:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "37C5"
+                    },
+                    "position": {
+                        "latitude": -36.848467,
+                        "longitude": 174.765483,
+                        "bearing": "17"
+                    },
+                    "timestamp": 1535531303.899,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "71035641-3beb-b1b8-7283-74a9525c9964",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "14797130502-20180815114333_v70.9",
+                        "route_id": "79702-20180815114333_v70.9",
+                        "start_time": "19:48:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "3801"
+                    },
+                    "position": {
+                        "latitude": -36.8405,
+                        "longitude": 174.755633,
+                        "bearing": "117"
+                    },
+                    "timestamp": 1535531307,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "0307fe01-5b28-3de8-f82a-22e0a242470f",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "8300141161-20180815114333_v70.9",
+                        "route_id": "30005-20180815114333_v70.9",
+                        "start_time": "19:45:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "6221"
+                    },
+                    "position": {
+                        "latitude": -36.84513296,
+                        "longitude": 174.76643459
+                    },
+                    "timestamp": 1535531294,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "7f8a0cdd-f514-64ca-ac1d-cc3e057c45e0",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "23500144518-20180815114333_v70.9",
+                        "route_id": "830001-20180815114333_v70.9",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "ADL        808"
+                    },
+                    "position": {
+                        "latitude": -37.194505,
+                        "longitude": 174.906415,
+                        "bearing": 166.8
+                    },
+                    "timestamp": 1535531280
+                }
+            },
+            {
+                "id": "d3bbc754-1e82-2263-4f7d-1609006bb800",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "50051144526-20180815114333_v70.9",
+                        "route_id": "850001-20180815114333_v70.9",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "AMP        605"
+                    },
+                    "position": {
+                        "latitude": -36.99441,
+                        "longitude": 174.87624,
+                        "bearing": 66
+                    },
+                    "timestamp": 1535531279
+                }
+            },
+            {
+                "id": "5aec3a05-6c94-952f-0a67-c3a7f1e495a6",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1085125214-20180815114333_v70.9",
+                        "route_id": "12004-20180815114333_v70.9",
+                        "start_time": "20:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "56D9"
+                    },
+                    "position": {
+                        "latitude": -36.816733,
+                        "longitude": 174.622583,
+                        "bearing": "256"
+                    },
+                    "timestamp": 1535531298,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "232aa990-a785-f9d7-ae83-52532d49efdc",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "440137895-20180815114333_v70.9",
+                        "route_id": "06601-20180815114333_v70.9",
+                        "start_time": "18:45:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5A57"
+                    },
+                    "position": {
+                        "latitude": -36.852435,
+                        "longitude": 174.70413333
+                    },
+                    "timestamp": 1535531285
+                }
+            },
+            {
+                "id": "ca82c4c8-62bb-e380-a3f9-c06edf95629b",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "465138103-20180815114333_v70.9",
+                        "route_id": "02202-20180815114333_v70.9",
+                        "start_time": "20:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "3075"
+                    },
+                    "position": {
+                        "latitude": -36.880017,
+                        "longitude": 174.725983,
+                        "bearing": "227"
+                    },
+                    "timestamp": 1535531287.466,
+                    "occupancy_status": 2
+                }
+            },
+            {
+                "id": "3304cddc-2ee5-161b-6d67-06e750204b9d",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "7380123837-20180815114333_v70.9",
+                        "route_id": "38013-20180815114333_v70.9",
+                        "start_time": "20:15:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "65F9"
+                    },
+                    "position": {
+                        "latitude": -36.98648836,
+                        "longitude": 174.84794067
+                    },
+                    "timestamp": 1535531307,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "1815ce62-7250-4455-80f3-5738c5bb926c",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "14313121038-20180815114333_v70.9",
+                        "route_id": "31303-20180815114333_v70.9",
+                        "start_time": "20:15:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "6660"
+                    },
+                    "position": {
+                        "latitude": -36.9555,
+                        "longitude": 174.790483,
+                        "bearing": "199"
+                    },
+                    "timestamp": 1535531285.543,
+                    "occupancy_status": 1
+                }
+            },
+            {
+                "id": "39725e72-6cc2-f5df-8aaf-5cf63c5da079",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "459137836-20180815114333_v70.9",
+                        "route_id": "77502-20180815114333_v70.9",
+                        "start_time": "18:30:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "30BD"
+                    },
+                    "position": {
+                        "latitude": -36.84395667,
+                        "longitude": 174.7563
+                    },
+                    "timestamp": 1535531008
+                }
+            },
+            {
+                "id": "a4110a2d-71f7-66c2-67c0-01571f4d616c",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "457138110-20180815114333_v70.9",
+                        "route_id": "76201-20180815114333_v70.9",
+                        "start_time": "20:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "36E2"
+                    },
+                    "position": {
+                        "latitude": -36.84425667,
+                        "longitude": 174.764065
+                    },
+                    "timestamp": 1535531238,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "154c565d-02cb-7402-7f3f-5aaf5dba5229",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "18025100574-20180815114333_v70.9",
+                        "route_id": "00202-20180815114333_v70.9",
+                        "start_time": "19:55:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "7D97"
+                    },
+                    "position": {
+                        "latitude": -36.819317,
+                        "longitude": 175.05815,
+                        "bearing": "112"
+                    },
+                    "timestamp": 1535531295,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "ae4672e6-6d9c-f9b4-472b-13c9b168072a",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1090109462-20180815114333_v70.9",
+                        "route_id": "13301-20180815114333_v70.9",
+                        "start_time": "20:05:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5C4B"
+                    },
+                    "position": {
+                        "latitude": -36.86697472,
+                        "longitude": 174.73961737
+                    },
+                    "timestamp": 1535531307,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "e2de3452-2fbb-4f00-513f-65761a62020c",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1146102749-20180815114333_v70.9",
+                        "route_id": "71101-20180815114333_v70.9",
+                        "start_time": "19:45:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "666E"
+                    },
+                    "position": {
+                        "latitude": -36.95052833,
+                        "longitude": 174.89936667
+                    },
+                    "timestamp": 1535531228
+                }
+            },
+            {
+                "id": "74545bbb-bb01-0984-832f-7c2ea857ebfd",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1062089212-20180815114333_v70.9",
+                        "route_id": "03102-20180815114333_v70.9",
+                        "start_time": "20:10:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "6661"
+                    },
+                    "position": {
+                        "latitude": -36.96255,
+                        "longitude": 174.877217,
+                        "bearing": "268"
+                    },
+                    "timestamp": 1535531306.805,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "f9ae0b1c-e601-8ccb-b39a-35123a10ba94",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "442138147-20180815114333_v70.9",
+                        "route_id": "07501-20180815114333_v70.9",
+                        "start_time": "20:15:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "2C9B"
+                    },
+                    "position": {
+                        "latitude": -36.87533395,
+                        "longitude": 174.78537428
+                    },
+                    "timestamp": 1535531309,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "f42dcfc8-ab33-e71e-4244-ec89f165f090",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "4974089130-20180815114333_v70.9",
+                        "route_id": "97401-20180815114333_v70.9",
+                        "start_time": "19:45:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5217"
+                    },
+                    "position": {
+                        "latitude": -36.842933,
+                        "longitude": 174.7654,
+                        "bearing": "0"
+                    },
+                    "timestamp": 1535531169.5,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "bd591989-75a3-8ee4-2b10-249c1d463281",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "464138097-20180815114333_v70.9",
+                        "route_id": "02204-20180815114333_v70.9",
+                        "start_time": "19:52:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "2F71"
+                    },
+                    "position": {
+                        "latitude": -36.91021667,
+                        "longitude": 174.68107833
+                    },
+                    "timestamp": 1535531297,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "1e84ade8-c56b-5c48-33e2-f3764e5c3eeb",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1064120989-20180815114333_v70.9",
+                        "route_id": "03302-20180815114333_v70.9",
+                        "start_time": "19:30:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5601"
+                    },
+                    "position": {
+                        "latitude": -37.058225,
+                        "longitude": 174.94146333
+                    },
+                    "timestamp": 1535531206,
+                    "occupancy_status": 1
+                }
+            },
+            {
+                "id": "c4e6cd61-7d36-e7d1-a15b-1573a3ce9559",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1149102753-20180815114333_v70.9",
+                        "route_id": "07207-20180815114333_v70.9",
+                        "start_time": "19:49:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5EC8"
+                    },
+                    "position": {
+                        "latitude": -36.89783333,
+                        "longitude": 174.84916833
+                    },
+                    "timestamp": 1535531041
+                }
+            },
+            {
+                "id": "36abe603-753f-573f-0f57-c1ea6e686df0",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1140121041-20180815114333_v70.9",
+                        "route_id": "03508-20180815114333_v70.9",
+                        "start_time": "20:15:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5E6E"
+                    },
+                    "position": {
+                        "latitude": -36.967517,
+                        "longitude": 174.924017,
+                        "bearing": "261"
+                    },
+                    "timestamp": 1535531303.664,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "cb8dc6c9-c5a0-2a4d-b14e-a9e7b7e698c3",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "2362143286-20180815114333_v70.9",
+                        "route_id": "36203-20180815114333_v70.9",
+                        "start_time": "19:30:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "560D"
+                    },
+                    "position": {
+                        "latitude": -37.03296167,
+                        "longitude": 174.92016167
+                    },
+                    "timestamp": 1535531114
+                }
+            },
+            {
+                "id": "a8f8f5ba-7ffe-3179-9b68-83e8c8b403c3",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "473138169-20180815114333_v70.9",
+                        "route_id": "02705-20180815114333_v70.9",
+                        "start_time": "20:22:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "2C94"
+                    },
+                    "position": {
+                        "latitude": -36.917667,
+                        "longitude": 174.749967,
+                        "bearing": "46"
+                    },
+                    "timestamp": 1535531300.833,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "717fd3cb-2847-7c81-d0f7-05a526f781df",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1087109410-20180815114333_v70.9",
+                        "route_id": "12502-20180815114333_v70.9",
+                        "start_time": "19:35:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "2F4A"
+                    },
+                    "position": {
+                        "latitude": -36.67877,
+                        "longitude": 174.44994167
+                    },
+                    "timestamp": 1535531288,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "68916eaa-2d49-d413-4c3a-5282bb72e1fc",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "442138031-20180815114333_v70.9",
+                        "route_id": "07501-20180815114333_v70.9",
+                        "start_time": "19:30:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "2C8E"
+                    },
+                    "position": {
+                        "latitude": -36.8405,
+                        "longitude": 174.755633,
+                        "bearing": "0"
+                    },
+                    "timestamp": 1535531297.5,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "fcdf1606-72a7-a071-212e-39ca89bcea88",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1124109466-20180815114333_v70.9",
+                        "route_id": "01408-20180815114333_v70.9",
+                        "start_time": "20:10:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "2CBB"
+                    },
+                    "position": {
+                        "latitude": -36.8774,
+                        "longitude": 174.632883,
+                        "bearing": "302"
+                    },
+                    "timestamp": 1535531304.553,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "9a11b9d1-fe7a-a432-179d-1c86058bb4cc",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "5361143315-20180815114333_v70.9",
+                        "route_id": "36101-20180815114333_v70.9",
+                        "start_time": "20:15:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "56F6"
+                    },
+                    "position": {
+                        "latitude": -37.03195,
+                        "longitude": 174.860217,
+                        "bearing": "340"
+                    },
+                    "timestamp": 1535531277.187,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "d8ec0da9-a7ea-e5ca-d3ec-22fd7898384a",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1144120999-20180815114333_v70.9",
+                        "route_id": "35504-20180815114333_v70.9",
+                        "start_time": "19:35:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5E69"
+                    },
+                    "position": {
+                        "latitude": -36.993667,
+                        "longitude": 174.878267,
+                        "bearing": "0"
+                    },
+                    "timestamp": 1535531184.5,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "8d893052-a5ca-6b32-7057-8fda61656750",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "439138114-20180815114333_v70.9",
+                        "route_id": "03007-20180815114333_v70.9",
+                        "start_time": "20:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "30B9"
+                    },
+                    "position": {
+                        "latitude": -36.853433,
+                        "longitude": 174.763333,
+                        "bearing": "17"
+                    },
+                    "timestamp": 1535531267.945,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "f34a0fec-670a-e2c9-9ed4-d195bdae053c",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "2325143290-20180815114333_v70.9",
+                        "route_id": "32504-20180815114333_v70.9",
+                        "start_time": "19:35:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "67EB"
+                    },
+                    "position": {
+                        "latitude": -36.96856333,
+                        "longitude": 174.798605
+                    },
+                    "timestamp": 1535531219,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "122289aa-c2a4-732a-09a6-8aa3c28b2d69",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "3100089256-20180815114333_v70.9",
+                        "route_id": "10002-20180815114333_v70.9",
+                        "start_time": "20:25:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "586F"
+                    },
+                    "position": {
+                        "latitude": -36.846133,
+                        "longitude": 174.75655,
+                        "bearing": "286"
+                    },
+                    "timestamp": 1535531304.419,
+                    "occupancy_status": 2
+                }
+            },
+            {
+                "id": "74a90478-43dc-4613-2835-def0b38d40fe",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1089109478-20180815114333_v70.9",
+                        "route_id": "13202-20180815114333_v70.9",
+                        "start_time": "20:17:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5C50"
+                    },
+                    "position": {
+                        "latitude": -36.863467,
+                        "longitude": 174.748183,
+                        "bearing": "222"
+                    },
+                    "timestamp": 1535531303.024,
+                    "occupancy_status": 1
+                }
+            },
+            {
+                "id": "8b1d4928-b6f3-e069-f933-4b9c1977d432",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "467138048-20180815114333_v70.9",
+                        "route_id": "02402-20180815114333_v70.9",
+                        "start_time": "19:35:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "2F59"
+                    },
+                    "position": {
+                        "latitude": -36.90920833,
+                        "longitude": 174.67311167
+                    },
+                    "timestamp": 1535531181,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "69b027f7-fec5-0bb8-54b2-746bb3004fc7",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "452138004-20180815114333_v70.9",
+                        "route_id": "67011-20180815114333_v70.9",
+                        "start_time": "19:15:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "37FB"
+                    },
+                    "position": {
+                        "latitude": -36.94774097,
+                        "longitude": 174.8337793
+                    },
+                    "timestamp": 1535531170
+                }
+            },
+            {
+                "id": "ee8dfde6-4b22-168b-d367-1b2dba9eb63a",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "448138126-20180815114333_v70.9",
+                        "route_id": "29502-20180815114333_v70.9",
+                        "start_time": "20:05:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "30AE"
+                    },
+                    "position": {
+                        "latitude": -36.89115,
+                        "longitude": 174.7661,
+                        "bearing": "192"
+                    },
+                    "timestamp": 1535531279,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "cfa1d6b5-ae42-5e6f-bd5b-3d95dd400a1e",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "469145950-20180815114333_v70.9",
+                        "route_id": "02506-20180815114333_v70.9",
+                        "start_time": "20:10:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "2F45"
+                    },
+                    "position": {
+                        "latitude": -36.89271958,
+                        "longitude": 174.74564341
+                    },
+                    "timestamp": 1535531301,
+                    "occupancy_status": 1
+                }
+            },
+            {
+                "id": "a7895d9b-7b78-2648-e943-e8d7bae83861",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "2377089249-20180815114333_v70.9",
+                        "route_id": "37702-20180815114333_v70.9",
+                        "start_time": "20:25:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "55F3"
+                    },
+                    "position": {
+                        "latitude": -37.06653332,
+                        "longitude": 174.93365601
+                    },
+                    "timestamp": 1535531306,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "971eaaf1-9404-c3aa-479e-5cad048bd0c0",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "50051144522-20180815114333_v70.9",
+                        "route_id": "850004-20180815114333_v70.9",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "AMP        484"
+                    },
+                    "position": {
+                        "latitude": -36.87697,
+                        "longitude": 174.85371,
+                        "bearing": 163
+                    },
+                    "timestamp": 1535531290
+                }
+            },
+            {
+                "id": "f2b79817-cb90-4671-189a-698c3fb16e85",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "8301134768-20180815114333_v70.9",
+                        "route_id": "30014-20180815114333_v70.9",
+                        "start_time": "20:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "6224"
+                    },
+                    "position": {
+                        "latitude": -36.902475,
+                        "longitude": 174.72152
+                    },
+                    "timestamp": 1535531290,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "90d00c24-d60a-eda6-85eb-8fcccda66fd8",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1141102737-20180815114333_v70.9",
+                        "route_id": "07005-20180815114333_v70.9",
+                        "start_time": "19:30:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5EB0"
+                    },
+                    "position": {
+                        "latitude": -36.84512833,
+                        "longitude": 174.76867333
+                    },
+                    "timestamp": 1535531195,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "e9ee85b4-32c0-945e-372b-5d0e0588b4f3",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "23100144500-20180815114333_v70.9",
+                        "route_id": "820002-20180815114333_v70.9",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "AMP        390"
+                    },
+                    "position": {
+                        "latitude": -37.06604983333333,
+                        "longitude": 174.94767,
+                        "bearing": 330
+                    },
+                    "timestamp": 1535531296
+                }
+            },
+            {
+                "id": "4e1f09c3-b9fc-3e9a-905e-da2a3b415e3f",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "4973089210-20180815114333_v70.9",
+                        "route_id": "97302-20180815114333_v70.9",
+                        "start_time": "20:08:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "5222"
+                    },
+                    "position": {
+                        "latitude": -36.80640667,
+                        "longitude": 174.705515
+                    },
+                    "timestamp": 1535531304,
+                    "occupancy_status": 1
+                }
+            },
+            {
+                "id": "11e97152-e451-8329-c589-1ef7089a8415",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "23100144311-20180815114333_v70.9",
+                        "route_id": "820001-20180815114333_v70.9",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "AMP        443"
+                    },
+                    "position": {
+                        "latitude": -37.06392,
+                        "longitude": 174.94558999999995,
+                        "bearing": 235
+                    },
+                    "timestamp": 1535531283
+                }
+            },
+            {
+                "id": "b40fc513-b0f5-6f68-5f28-f98d98e24f5e",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "4974089244-20180815114333_v70.9",
+                        "route_id": "97402-20180815114333_v70.9",
+                        "start_time": "20:23:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "520D"
+                    },
+                    "position": {
+                        "latitude": -36.844633,
+                        "longitude": 174.7518,
+                        "bearing": "286"
+                    },
+                    "timestamp": 1535531302.649,
+                    "occupancy_status": 1
+                }
+            },
+            {
+                "id": "28771f07-768f-1674-cf02-55e097ed9c5e",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "14306133948-20180815114333_v70.9",
+                        "route_id": "30901-20180815114333_v70.9",
+                        "start_time": "20:30:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "665C"
+                    },
+                    "position": {
+                        "latitude": -36.968983,
+                        "longitude": 174.799667
+                    },
+                    "timestamp": 1535531266,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "90483bd2-28d1-4956-3971-6afa43ae124f",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "476138153-20180815114333_v70.9",
+                        "route_id": "72113-20180815114333_v70.9",
+                        "start_time": "20:15:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "37E2"
+                    },
+                    "position": {
+                        "latitude": -36.8455,
+                        "longitude": 174.73545,
+                        "bearing": "258"
+                    },
+                    "timestamp": 1535531306.928,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "5af5e30e-b4eb-6daf-7c01-2825b39cdd4e",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "457138150-20180815114333_v70.9",
+                        "route_id": "76202-20180815114333_v70.9",
+                        "start_time": "20:15:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "3748"
+                    },
+                    "position": {
+                        "latitude": -36.86175,
+                        "longitude": 174.821733,
+                        "bearing": "120"
+                    },
+                    "timestamp": 1535531303.469,
+                    "occupancy_status": 2
+                }
+            },
+            {
+                "id": "e817a89e-410c-a12f-8a44-04bc51818239",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "2378143309-20180815114333_v70.9",
+                        "route_id": "37802-20180815114333_v70.9",
+                        "start_time": "20:01:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "56FC"
+                    },
+                    "position": {
+                        "latitude": -37.05845333,
+                        "longitude": 174.94002667
+                    },
+                    "timestamp": 1535531235,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "a1163ea9-a644-de7a-9096-b5cd3075a8d0",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "1982100600-20180815114333_v70.9",
+                        "route_id": "98206-20180815114333_v70.9",
+                        "start_time": "20:30:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "3778"
+                    },
+                    "position": {
+                        "latitude": -36.624267,
+                        "longitude": 174.667567
+                    },
+                    "timestamp": 1535531205,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "efccfea4-c890-69e6-0bee-92de2cb1a041",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "5361143299-20180815114333_v70.9",
+                        "route_id": "36102-20180815114333_v70.9",
+                        "start_time": "19:45:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "55F2"
+                    },
+                    "position": {
+                        "latitude": -37.03011795,
+                        "longitude": 174.8980467
+                    },
+                    "timestamp": 1535531297,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "2b827c41-472b-def6-7a4d-ec0f26a673d0",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "14306133943-20180815114333_v70.9",
+                        "route_id": "30901-20180815114333_v70.9",
+                        "start_time": "20:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "672E"
+                    },
+                    "position": {
+                        "latitude": -36.9226,
+                        "longitude": 174.771833,
+                        "bearing": "273"
+                    },
+                    "timestamp": 1535531302.778,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "1829f2e0-1463-1903-e9c0-3c6920457fd9",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "13170097367-20180815114333_v70.9",
+                        "route_id": "17028-20180815114333_v70.9",
+                        "start_time": "20:00:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "57EA"
+                    },
+                    "position": {
+                        "latitude": -36.960267,
+                        "longitude": 174.649617,
+                        "bearing": "0"
+                    },
+                    "timestamp": 1535531301.5,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "bb522311-3ad8-3da0-3b48-f0b670bd4f97",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "23500144476-20180815114333_v70.9",
+                        "route_id": "830001-20180815114333_v70.9",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "ADL        801"
+                    },
+                    "position": {
+                        "latitude": -37.20350833333333,
+                        "longitude": 174.91010166666666,
+                        "bearing": 296.8
+                    },
+                    "timestamp": 1535531265
+                }
+            },
+            {
+                "id": "58c1a886-0ec5-a657-9a3e-b144c3a00914",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "14797130519-20180815114333_v70.9",
+                        "route_id": "79702-20180815114333_v70.9",
+                        "start_time": "19:54:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "36B3"
+                    },
+                    "position": {
+                        "latitude": -36.84619921,
+                        "longitude": 174.75680639
+                    },
+                    "timestamp": 1535531309,
+                    "occupancy_status": 0
+                }
+            },
+            {
+                "id": "f5f3bd67-6729-ed71-c39b-c6cf04a016db",
+                "is_deleted": false,
+                "vehicle": {
+                    "trip": {
+                        "trip_id": "12913097379-20180815114333_v70.9",
+                        "route_id": "91301-20180815114333_v70.9",
+                        "start_time": "20:10:00",
+                        "schedule_relationship": 0
+                    },
+                    "vehicle": {
+                        "id": "3745"
+                    },
+                    "position": {
+                        "latitude": -36.78374084,
+                        "longitude": 174.75190892
+                    },
+                    "timestamp": 1535531308,
+                    "occupancy_status": 0
+                }
+            }
+        ]
+    },
+    "error": null
+}

--- a/spec/fixtures/get-vehicle-positions-with-trip-id-successful.json
+++ b/spec/fixtures/get-vehicle-positions-with-trip-id-successful.json
@@ -1,0 +1,33 @@
+{
+  "status": "OK",
+  "response": {
+    "entity": [{
+      "id": "2c68aea3-703a-5724-3f54-63200b3fe95e",
+      "is_deleted": false,
+      "vehicle": {
+        "trip": {
+          "trip_id": "439138218-20180815114333_v70.9",
+          "route_id": "03007-20180815114333_v70.9",
+          "start_time": "20:45:00",
+          "schedule_relationship": 0
+        },
+        "vehicle": {
+          "id": "37FA"
+        },
+        "position": {
+          "latitude": -36.9203,
+          "longitude": 174.784983,
+          "bearing": "353"
+        },
+        "timestamp": 1535532451.88,
+        "occupancy_status": 0
+      }
+    }],
+    "header": {
+      "gtfs_realtime_version": "1.0",
+      "incrementality": 0,
+      "timestamp": 1535532477.516
+    }
+  },
+  "error": null
+}


### PR DESCRIPTION
Changes:
* Add VehiclePositions namespace
* Add `#get_vehicle_positions` method to fetch all buses operating at the time of the request
* Implement an optional parameter to the `#get_vehicle_positions` method to specify vehicle positions per trip_id